### PR TITLE
Migrate aws

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,7 +165,7 @@ jobs:
     env:
       AWS_DEFAULT_REGION: us-west-2
       AWS_ECR_REPOSITORY_NAME: dirtviz-worker
-      AWS_ECS_SERVICE_NAME: dirtviz-service-celery
+      AWS_ECS_SERVICE_NAME: dirtviz-service-worker
       AWS_ECS_CLUSTER_NAME: dirtviz-cluster
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
     env:
       AWS_DEFAULT_REGION: us-west-2
       AWS_ECR_REPOSITORY_NAME: dirtviz-ecr
-      AWS_ECS_SERVICE_NAME: dirtviz-service
+      AWS_ECS_SERVICE_NAME: dirtviz-service-api
       AWS_ECS_CLUSTER_NAME: dirtviz-cluster
 
     steps:
@@ -165,8 +165,8 @@ jobs:
     env:
       AWS_DEFAULT_REGION: us-west-2
       AWS_ECR_REPOSITORY_NAME: dirtviz-worker-ecr
-      AWS_ECS_SERVICE_NAME: dirtviz-worker-service
-      AWS_ECS_CLUSTER_NAME: dirtviz-worker-cluster
+      AWS_ECS_SERVICE_NAME: dirtviz-service-celery
+      AWS_ECS_CLUSTER_NAME: dirtviz-cluster
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,10 +103,6 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Download task definition
-        run: |
-          aws ecs describe-task-definition --task-definition dirtviz-task-definition --query taskDefinition > aws-task-definition.json
-
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:
@@ -142,6 +138,10 @@ jobs:
               -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition --task-definition dirtviz-task-definition --query taskDefinition > aws-task-definition.json
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
@@ -183,9 +183,6 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Download task definition
-        run: |
-          aws ecs describe-task-definition --task-definition dirtviz-worker-task-definition --query taskDefinition > aws-task-definition.json
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:
@@ -220,6 +217,11 @@ jobs:
               -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition --task-definition dirtviz-worker-task-definition --query taskDefinition > aws-task-definition.json
+
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1
@@ -227,6 +229,7 @@ jobs:
           task-definition: aws-task-definition.json
           container-name: ${{ env.AWS_ECR_REPOSITORY_NAME }}
           image: ${{ steps.build-image.outputs.image }}
+
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Download task definition
         run: |
-          aws ecs describe-task-definition --task-definition dirtviz-task-definition --query taskDefinition > aws-task-definition.json
+          aws ecs describe-task-definition --task-definition dirtviz-task-api --query taskDefinition > aws-task-definition.json
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
@@ -220,7 +220,7 @@ jobs:
 
       - name: Download task definition
         run: |
-          aws ecs describe-task-definition --task-definition dirtviz-worker-task-definition --query taskDefinition > aws-task-definition.json
+          aws ecs describe-task-definition --task-definition dirtviz-task-worker --query taskDefinition > aws-task-definition.json
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AWS_DEFAULT_REGION: us-west-2
-      AWS_ECR_REPOSITORY_NAME: dirtviz-ecr
+      AWS_ECR_REPOSITORY_NAME: dirtviz-api
       AWS_ECS_SERVICE_NAME: dirtviz-service-api
       AWS_ECS_CLUSTER_NAME: dirtviz-cluster
 
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AWS_DEFAULT_REGION: us-west-2
-      AWS_ECR_REPOSITORY_NAME: dirtviz-worker-ecr
+      AWS_ECR_REPOSITORY_NAME: dirtviz-worker
       AWS_ECS_SERVICE_NAME: dirtviz-service-celery
       AWS_ECS_CLUSTER_NAME: dirtviz-cluster
 


### PR DESCRIPTION
Updated `deploy.yml` action for new aws infrastructure. Can delete branch after merge. @aleclevy once you look at the code feel free to merge into `main` so that `main` pushes get automatically pushed to aws. Also included below some notes during the migration procedure

- Worked on AWS deployment
- See the following for why celery has to be in the public subet (https://stackoverflow.com/questions/61265108/aws-ecs-fargate-resourceinitializationerror-unable-to-pull-secrets-or-registry)
- The worker is built for x86 while the backend is build for arm. Possible future optimization
- Needed to create a special policy for the s3 bucket to allow for special access via cloudfront
