### PR TITLE
Fix Windows line ending issues in Docker scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,39 @@
+# Set default behavior to automatically normalize line endings
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout
+*.txt text
+*.md text
+*.py text
+*.json text
+*.yml text
+*.yaml text
+*.html text
+*.css text
+*.js text
+
+# Shell scripts should always use LF line endings
+*.sh text eol=lf
+entrypoint.sh text eol=lf
+migrate.sh text eol=lf
+backend/entrypoint.sh text eol=lf
+backend/migrate.sh text eol=lf
+sql/restore.sh text eol=lf
+sql/backup.sh text eol=lf
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.svg binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,30 @@ docker compose up --build -d
 
 At this point the backend is accessible at [http://localhost:3000/](http://localhost:3000/), but will likely show a blank page in your web browser and throw an error. This is due to the database being empty, therefore there is no data to display.
 
+## Windows Development Note
+
+When developing on Windows, be aware that Git may automatically convert line endings from LF (Unix-style) to CRLF (Windows-style). This can cause issues with shell scripts run inside Docker containers, such as `entrypoint.sh` and `migrate.sh`, resulting in errors like "entrypoint.sh not found" or "bad interpreter".
+
+To address this, we've added a `.gitattributes` file that forces shell scripts to maintain LF line endings regardless of the operating system.
+
+### For New Repository Clones
+
+The `.gitattributes` file will automatically ensure proper line endings for new files.
+
+### For Existing Repository Clones
+
+If you encounter line ending issues with existing files:
+
+1. Make sure you've pulled the latest changes with the `.gitattributes` file
+2. Run: `git add --renormalize .`
+3. Commit these changes: `git commit -m "Normalize line endings"`
+4. Reset your working directory: `git checkout -- .`
+
+Alternatively, you can also:
+
+- Run `git config --global core.autocrlf input` to configure Git to preserve line endings
+- Clone the repository again
+
 ### Generating environmental variables
 
 The frontend and backend containers require environmental variables to be set in order to run. These are stored in a `.env` file in the root directory. The `.env` is used to provide the necessary environment variables to the local development containers and can be used as a base to setup environment variables for a production environment.


### PR DESCRIPTION
## Problem
Windows developers encounter "entrypoint.sh not found" errors when using Docker, caused by CRLF line endings in shell scripts.

## Solution
- Added .gitattributes file to enforce LF line endings for shell scripts
- Updated README with comprehensive guidance for Windows developers
- Explicitly configured critical scripts (entrypoint.sh, migrate.sh) to use LF

## Testing
Testing on a Unix-based system (macOS) confirmed that:
1. The .gitattributes file is correctly recognized by Git
2. Shell scripts created with Windows line endings fail in Docker with the exact error mentioned in the bug report
3. The solution works as expected for new files created after the .gitattributes file is in place
4. Existing files with incorrect line endings can be fixed using the Git commands provided in the README

This solution ensures shell scripts maintain Unix-style line endings (LF) regardless of the developer's operating system, preventing "bad interpreter" errors in Docker containers.

Note: While developed on macOS, this solution addresses the core issue - Git's line ending handling - which works across all platforms.