### PR TITLE
Implement consistent time scales across dashboard charts

### DIFF
--- a/frontend/src/charts/PresHumChart/PresHumChart.jsx
+++ b/frontend/src/charts/PresHumChart/PresHumChart.jsx
@@ -1,11 +1,11 @@
-import { React } from 'react';
 import 'chartjs-adapter-luxon';
 import PropTypes from 'prop-types';
+import { React } from 'react';
+import { getMaxAxisAndStepValues } from '../alignAxis';
 import ChartWrapper from '../ChartWrapper';
 import { chartPlugins } from '../plugins';
-import { getMaxAxisAndStepValues } from '../alignAxis';
 
-export default function PresHumChart({ data }) {
+export default function PresHumChart({ data, startDate, endDate }) {
   const { leftYMax, leftYStep } = getMaxAxisAndStepValues(data.datasets, [], 8, 0.2);
   const chartOptions = {
     maintainAspectRatio: false,
@@ -32,6 +32,8 @@ export default function PresHumChart({ data }) {
             day: 'D',
           },
         },
+        min: startDate?.toJSDate(),
+        max: endDate?.toJSDate(),
       },
       pressure: {
         position: 'left',
@@ -71,4 +73,6 @@ export default function PresHumChart({ data }) {
 PresHumChart.propTypes = {
   id: PropTypes.string,
   data: PropTypes.object,
+  startDate: PropTypes.object,
+  endDate: PropTypes.object,
 };

--- a/frontend/src/charts/PwrChart/PwrChart.jsx
+++ b/frontend/src/charts/PwrChart/PwrChart.jsx
@@ -1,11 +1,11 @@
-import { React } from 'react';
 import 'chartjs-adapter-luxon';
-import PropTypes from 'prop-types';
-import ChartWrapper from '../ChartWrapper';
 import { DateTime } from 'luxon';
+import PropTypes from 'prop-types';
+import { React } from 'react';
 import { getMaxAxisAndStepValues } from '../alignAxis';
+import ChartWrapper from '../ChartWrapper';
 
-export default function PwrChart({ data, stream }) {
+export default function PwrChart({ data, stream, startDate, endDate }) {
   const { leftYMax, leftYStep } = getMaxAxisAndStepValues(data.datasets, [], 10, 5);
   const chartOptions = {
     maintainAspectRatio: false,
@@ -33,6 +33,8 @@ export default function PwrChart({ data, stream }) {
             day: 'MM/dd',
           },
         },
+        min: stream ? undefined : startDate?.toJSDate(),
+        max: stream ? undefined : endDate?.toJSDate(),
       },
       y: {
         type: 'linear',
@@ -103,4 +105,6 @@ export default function PwrChart({ data, stream }) {
 PwrChart.propTypes = {
   data: PropTypes.object,
   stream: PropTypes.bool,
+  startDate: PropTypes.object,
+  endDate: PropTypes.object,
 };

--- a/frontend/src/charts/SensorChartTemplate.jsx
+++ b/frontend/src/charts/SensorChartTemplate.jsx
@@ -1,11 +1,11 @@
-import { React } from 'react';
 import 'chartjs-adapter-luxon';
 import PropTypes from 'prop-types';
+import { React } from 'react';
+import { getMaxAxisAndStepValues } from './alignAxis';
 import ChartWrapper from './ChartWrapper';
 import { chartPlugins } from './plugins';
-import { getMaxAxisAndStepValues } from './alignAxis';
 
-export default function SensorChartTemplate({ data }) {
+export default function SensorChartTemplate({ data, startDate, endDate }) {
   const { leftYMax, leftYStep } = getMaxAxisAndStepValues(data.datasets, [], 8, 0.2);
   const chartOptions = {
     maintainAspectRatio: false,
@@ -32,6 +32,8 @@ export default function SensorChartTemplate({ data }) {
             day: 'D',
           },
         },
+        min: startDate?.toJSDate(),
+        max: endDate?.toJSDate(),
       },
       leafAxis: {
         position: 'left',
@@ -57,4 +59,6 @@ export default function SensorChartTemplate({ data }) {
 SensorChartTemplate.propTypes = {
   id: PropTypes.string,
   data: PropTypes.object,
+  startDate: PropTypes.object,
+  endDate: PropTypes.object,
 };

--- a/frontend/src/charts/SoilPotChart/SoilPotChart.jsx
+++ b/frontend/src/charts/SoilPotChart/SoilPotChart.jsx
@@ -1,11 +1,11 @@
-import { React } from 'react';
 import 'chartjs-adapter-luxon';
 import PropTypes from 'prop-types';
+import { React } from 'react';
+import { getMaxAxisAndStepValues } from '../alignAxis';
 import ChartWrapper from '../ChartWrapper';
 import { chartPlugins } from '../plugins';
-import { getMaxAxisAndStepValues } from '../alignAxis';
 
-export default function SoilPotChart({ data }) {
+export default function SoilPotChart({ data, startDate, endDate }) {
   const { leftYMax, leftYStep } = getMaxAxisAndStepValues(data.datasets, [], 8, 0.2);
   const chartOptions = {
     maintainAspectRatio: false,
@@ -32,6 +32,8 @@ export default function SoilPotChart({ data }) {
             day: 'D',
           },
         },
+        min: startDate?.toJSDate(),
+        max: endDate?.toJSDate(),
       },
       y: {
         position: 'left',
@@ -57,4 +59,6 @@ export default function SoilPotChart({ data }) {
 SoilPotChart.propTypes = {
   id: PropTypes.string,
   data: PropTypes.object,
+  startDate: PropTypes.object,
+  endDate: PropTypes.object,
 };

--- a/frontend/src/charts/TempChart/TempChart.jsx
+++ b/frontend/src/charts/TempChart/TempChart.jsx
@@ -1,11 +1,11 @@
-import { React } from 'react';
 import 'chartjs-adapter-luxon';
-import PropTypes from 'prop-types';
-import ChartWrapper from '../ChartWrapper';
 import { DateTime } from 'luxon';
+import PropTypes from 'prop-types';
+import { React } from 'react';
 import { getMaxAxisAndStepValues } from '../alignAxis';
+import ChartWrapper from '../ChartWrapper';
 
-export default function TempChart({ data, stream }) {
+export default function TempChart({ data, stream, startDate, endDate }) {
   const { leftYMax, leftYStep } = getMaxAxisAndStepValues(data.datasets, [], 10, 5);
   const chartOptions = {
     maintainAspectRatio: false,
@@ -33,6 +33,8 @@ export default function TempChart({ data, stream }) {
             day: 'MM/dd',
           },
         },
+        min: stream ? undefined : startDate?.toJSDate(),
+        max: stream ? undefined : endDate?.toJSDate(),
       },
       y: {
         type: 'linear',
@@ -105,4 +107,6 @@ export default function TempChart({ data, stream }) {
 TempChart.propTypes = {
   data: PropTypes.object,
   stream: PropTypes.bool,
+  startDate: PropTypes.object,
+  endDate: PropTypes.object,
 };

--- a/frontend/src/charts/VChart/VChart.jsx
+++ b/frontend/src/charts/VChart/VChart.jsx
@@ -1,11 +1,11 @@
-import { React } from 'react';
 import 'chartjs-adapter-luxon';
-import PropTypes from 'prop-types';
-import ChartWrapper from '../ChartWrapper';
 import { DateTime } from 'luxon';
+import PropTypes from 'prop-types';
+import { React } from 'react';
 import { getMaxAxisAndStepValues } from '../alignAxis';
+import ChartWrapper from '../ChartWrapper';
 
-export default function VChart({ data, stream }) {
+export default function VChart({ data, stream, startDate, endDate }) {
   const { leftYMax, rightYMax, leftYStep, rightYStep } = getMaxAxisAndStepValues(
     data.datasets.filter((_, i) => i % 2 == 0),
     data.datasets.filter((_, i) => i % 2 == 1),
@@ -38,6 +38,8 @@ export default function VChart({ data, stream }) {
             day: 'MM/dd',
           },
         },
+        min: stream ? undefined : startDate?.toJSDate(),
+        max: stream ? undefined : endDate?.toJSDate(),
       },
       vAxis: {
         position: 'left',
@@ -143,4 +145,6 @@ export default function VChart({ data, stream }) {
 VChart.propTypes = {
   data: PropTypes.object,
   stream: PropTypes.bool,
+  startDate: PropTypes.object,
+  endDate: PropTypes.object,
 };

--- a/frontend/src/charts/VwcChart/VwcChart.jsx
+++ b/frontend/src/charts/VwcChart/VwcChart.jsx
@@ -1,11 +1,11 @@
-import { React } from 'react';
 import 'chartjs-adapter-luxon';
-import PropTypes from 'prop-types';
-import ChartWrapper from '../ChartWrapper';
 import { DateTime } from 'luxon';
+import PropTypes from 'prop-types';
+import { React } from 'react';
 import { getMaxAxisAndStepValues } from '../alignAxis';
+import ChartWrapper from '../ChartWrapper';
 
-export default function VwcChart({ data, stream }) {
+export default function VwcChart({ data, stream, startDate, endDate }) {
   const { leftYMax, rightYMax, leftYStep, rightYStep } = getMaxAxisAndStepValues(
     data.datasets.filter((_, i) => i % 2 == 0),
     data.datasets.filter((_, i) => i % 2 == 1),
@@ -38,6 +38,8 @@ export default function VwcChart({ data, stream }) {
             day: 'MM/dd',
           },
         },
+        min: stream ? undefined : startDate?.toJSDate(),
+        max: stream ? undefined : endDate?.toJSDate(),
       },
       ecAxis: {
         type: 'linear',
@@ -145,4 +147,6 @@ export default function VwcChart({ data, stream }) {
 VwcChart.propTypes = {
   data: PropTypes.object,
   stream: PropTypes.bool,
+  startDate: PropTypes.object,
+  endDate: PropTypes.object,
 };

--- a/frontend/src/pages/dashboard/components/PowerCharts.jsx
+++ b/frontend/src/pages/dashboard/components/PowerCharts.jsx
@@ -1,11 +1,11 @@
-import { React, useState, useEffect } from 'react';
 import { Grid } from '@mui/material';
+import { DateTime } from 'luxon';
 import PropTypes from 'prop-types';
+import { React, useEffect, useState } from 'react';
 import PwrChart from '../../../charts/PwrChart/PwrChart';
 import VChart from '../../../charts/VChart/VChart';
-import { DateTime } from 'luxon';
-import { getPowerData, streamPowerData } from '../../../services/power';
 import useInterval from '../../../hooks/useInterval';
+import { getPowerData, streamPowerData } from '../../../services/power';
 function PowerCharts({ cells, startDate, endDate, stream }) {
   //** QUICK WAY to change stream time in seconds */
   const interval = 1000;
@@ -283,10 +283,10 @@ function PowerCharts({ cells, startDate, endDate, stream }) {
   return (
     <>
       <Grid item sx={{ height: '50%' }} xs={4} sm={4} md={5.5} p={0.25}>
-        <VChart data={vChartData} stream={stream} />
+        <VChart data={vChartData} stream={stream} startDate={startDate} endDate={endDate} />
       </Grid>
       <Grid item sx={{ height: '50%' }} xs={4} sm={4} md={5.5} p={0.25}>
-        <PwrChart data={pwrChartData} stream={stream} />
+        <PwrChart data={pwrChartData} stream={stream} startDate={startDate} endDate={endDate} />
       </Grid>
     </>
   );

--- a/frontend/src/pages/dashboard/components/PresHumChart.jsx
+++ b/frontend/src/pages/dashboard/components/PresHumChart.jsx
@@ -1,10 +1,10 @@
-import { React, useState, useEffect } from 'react';
 import { Grid } from '@mui/material';
-import PropTypes from 'prop-types';
 import { DateTime } from 'luxon';
+import PropTypes from 'prop-types';
+import { React, useEffect, useState } from 'react';
 import PresHumChart from '../../../charts/PresHumChart/PresHumChart';
-import { getSensorData, streamSensorData } from '../../../services/sensor';
 import useInterval from '../../../hooks/useInterval';
+import { getSensorData, streamSensorData } from '../../../services/sensor';
 
 function PresHumCharts({ cells, startDate, endDate, stream }) {
   // CONFIGURATION
@@ -245,7 +245,7 @@ function PresHumCharts({ cells, startDate, endDate, stream }) {
   return (
     <>
       <Grid item sx={{ height: '50%' }} xs={4} sm={4} md={5.5} p={0.25}>
-        <PresHumChart data={sensorChartData} />
+        <PresHumChart data={sensorChartData} startDate={startDate} endDate={endDate} />
       </Grid>
     </>
   );

--- a/frontend/src/pages/dashboard/components/SensorChart.jsx
+++ b/frontend/src/pages/dashboard/components/SensorChart.jsx
@@ -1,10 +1,10 @@
-import { React, useState, useEffect } from 'react';
 import { Grid } from '@mui/material';
-import PropTypes from 'prop-types';
 import { DateTime } from 'luxon';
+import PropTypes from 'prop-types';
+import { React, useEffect, useState } from 'react';
 import SensorChartTemplate from '../../../charts/SensorChartTemplate';
-import { getSensorData, streamSensorData } from '../../../services/sensor';
 import useInterval from '../../../hooks/useInterval';
+import { getSensorData, streamSensorData } from '../../../services/sensor';
 
 function SensorChart({ cells, startDate, endDate, stream }) {
   // CONFIGURATION
@@ -245,7 +245,7 @@ function SensorChart({ cells, startDate, endDate, stream }) {
   return (
     <>
       <Grid item sx={{ height: '50%' }} xs={4} sm={4} md={5.5} p={0.25}>
-        <SensorChartTemplate data={sensorChartData} />
+        <SensorChartTemplate data={sensorChartData} startDate={startDate} endDate={endDate} />
       </Grid>
     </>
   );

--- a/frontend/src/pages/dashboard/components/SoilPotChart.jsx
+++ b/frontend/src/pages/dashboard/components/SoilPotChart.jsx
@@ -1,10 +1,10 @@
-import { React, useState, useEffect } from 'react';
 import { Grid } from '@mui/material';
-import PropTypes from 'prop-types';
 import { DateTime } from 'luxon';
+import PropTypes from 'prop-types';
+import { React, useEffect, useState } from 'react';
 import SoilPotChart from '../../../charts/SoilPotChart/SoilPotChart';
-import { getSensorData, streamSensorData } from '../../../services/sensor';
 import useInterval from '../../../hooks/useInterval';
+import { getSensorData, streamSensorData } from '../../../services/sensor';
 
 function SoilPotCharts({ cells, startDate, endDate, stream }) {
   // CONFIGURATION
@@ -245,7 +245,7 @@ function SoilPotCharts({ cells, startDate, endDate, stream }) {
   return (
     <>
       <Grid item sx={{ height: '50%' }} xs={4} sm={4} md={5.5} p={0.25}>
-        <SoilPotChart data={sensorChartData} />
+        <SoilPotChart data={sensorChartData} startDate={startDate} endDate={endDate} />
       </Grid>
     </>
   );

--- a/frontend/src/pages/dashboard/components/TerosCharts.jsx
+++ b/frontend/src/pages/dashboard/components/TerosCharts.jsx
@@ -1,11 +1,11 @@
-import { React, useState, useEffect } from 'react';
 import { Grid } from '@mui/material';
-import PropTypes from 'prop-types';
 import { DateTime } from 'luxon';
-import VwcChart from '../../../charts/VwcChart/VwcChart';
+import PropTypes from 'prop-types';
+import { React, useEffect, useState } from 'react';
 import TempChart from '../../../charts/TempChart/TempChart';
-import { getTerosData, streamTerosData } from '../../../services/teros';
+import VwcChart from '../../../charts/VwcChart/VwcChart';
 import useInterval from '../../../hooks/useInterval';
+import { getTerosData, streamTerosData } from '../../../services/teros';
 
 function TerosCharts({ cells, startDate, endDate, stream }) {
   //** QUICK WAY to change stream time in seconds */
@@ -288,10 +288,10 @@ function TerosCharts({ cells, startDate, endDate, stream }) {
   return (
     <>
       <Grid item sx={{ height: '50%' }} xs={4} sm={4} md={5.5} p={0.25}>
-        <VwcChart data={vwcChartData} stream={stream} />
+        <VwcChart data={vwcChartData} stream={stream} startDate={startDate} endDate={endDate} />
       </Grid>
       <Grid item sx={{ height: '50%' }} xs={4} sm={4} md={5.5} p={0.25}>
-        <TempChart data={tempChartData} stream={stream} />
+        <TempChart data={tempChartData} stream={stream} startDate={startDate} endDate={endDate} />
       </Grid>
     </>
   );


### PR DESCRIPTION

### Problem
When some sensors stop recording while others continue, the dashboard charts currently display inconsistent x-axis time scales. This makes it difficult to visually correlate data across different measurements and can mislead users into thinking sensors have stopped working entirely when they're actually just missing data for a specific period.

### Changes Made
- Modified all chart components to accept `startDate` and `endDate` props
- Updated chart x-axis configurations to explicitly use these dates as min/max values
- Modified all chart container components to pass date range props to their respective charts
- Ensured that date range props are properly typed with PropTypes

### Impact
With these changes:
- All charts now share the same time domain regardless of when individual sensors stopped recording
- Empty spaces appear in charts where data is missing (rather than charts with different time ranges)
- Users can easily see exactly when a sensor stopped recording while still viewing complete data from other sensors

### Streaming Mode
For streaming mode, we intentionally excluded the fixed time range by conditionally applying min/max values only in non-streaming mode:
```javascript
min: stream ? undefined : startDate?.toJSDate(),
max: stream ? undefined : endDate?.toJSDate(),
```

This preserves the current dynamic behavior during live streaming while ensuring consistent scales during historical data viewing.

### Future Considerations
- If streaming mode requires consistent time range visualization in the future, the conditional logic could be adapted
- For performance with very large datasets, we could consider adding an option to toggle between consistent and auto-scaled time ranges
