### PR TITLE
Add export chart functionality to ChartWrapper component

### DIFF
--- a/frontend/src/charts/ChartWrapper.jsx
+++ b/frontend/src/charts/ChartWrapper.jsx
@@ -11,6 +11,9 @@ import Fullscreen from '../assets/maximize.svg';
 import zoomIn from '../assets/zoom-in.svg';
 import zoomOut from '../assets/zoom-out.svg';
 import downsample from '../assets/downsample.svg';
+import downloadIcon from '../assets/download.svg';
+import GetAppIcon from '@mui/icons-material/GetApp';
+
 import {
   Chart as ChartJS,
   LineController,
@@ -250,7 +253,19 @@ function ChartWrapper({ id, data, options, stream }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scaleRef]);
 
+  const handleExportChart = () => {
+    if (chartRef.current) {
+      const link = document.createElement('a');
+      link.href = chartRef.current.toBase64Image();
+      link.download = `chart-${id}-${new Date().toISOString().split('T')[0]}.png`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  };
+
   return (
+    
     <Box
       sx={{
         display: 'flex',
@@ -424,6 +439,34 @@ function ChartWrapper({ id, data, options, stream }) {
             <Box component='img' src={downsample} sx={{ width: '16px', height: '16px' }}></Box>
           </ToggleButton>
         </Tooltip>
+        
+        {/* Export Chart button */}
+        <Tooltip
+          title='Export Chart'
+          placement='bottom'
+          disableInteractive
+          slotProps={{
+            popper: {
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, -11],
+                  },
+                },
+              ],
+            },
+          }}
+        >
+          <ToggleButton 
+            value={false} 
+            onClick={handleExportChart} 
+            sx={{ width: '32px', height: '32px' }}
+          >
+            <GetAppIcon sx={{ width: '16px', height: '16px' }} />
+          </ToggleButton>
+        </Tooltip>
+        
         <Tooltip
           title='Fullscreen'
           placement='bottom'
@@ -610,6 +653,30 @@ function ChartWrapper({ id, data, options, stream }) {
                     <Box component='img' src={downsample} sx={{ width: '20px', height: '20px' }}></Box>
                   </ToggleButton>
                 </Tooltip>
+                
+                {/* Add Export button to fullscreen modal */}
+                <Tooltip
+                  title='Export Chart'
+                  placement='bottom'
+                  disableInteractive
+                  slotProps={{
+                    popper: {
+                      modifiers: [
+                        {
+                          name: 'offset',
+                          options: {
+                            offset: [0, -11],
+                          },
+                        },
+                      ],
+                    },
+                  }}
+                >
+                  <ToggleButton value={false} onClick={handleExportChart}>
+                    <Box component='img' src={downloadIcon} sx={{ width: '20px', height: '20px' }}></Box>
+                  </ToggleButton>
+                </Tooltip>
+                
                 <Tooltip
                   title='Windowed'
                   placement='bottom'


### PR DESCRIPTION
**Description**
This PR introduces a chart export function that enables users to export charts as PNG images. The export functionality uses Chart.js's built-in toBase64Image() method. This feature is helpful in sharing charts within reports, presentations, or communication channels without using screenshots.

**Changes Made**
- Added export button to chart controls sidebar
- Implemented handleExportChart function that renders the chart as a PNG image
- Added the export button on both regular view and fullscreen modal
- Implemented Material-UI's GetAppIcon on the regular view and a custom download icon on the fullscreen view

**How to Test**
1. Go to any page with charts
2. Click the download button in the chart controls sidebar
3. Check that the chart is downloaded as a PNG file with the naming format chart-[id]-[date].png

**Screenrecording**

https://github.com/user-attachments/assets/08cc01ca-57c6-4038-ba37-9b0dfd635197

**Related Issue**
Closes #384 




