### PR TITLE
Added a graph export feature

### DIFF
--- a/frontend/src/assets/download.svg
+++ b/frontend/src/assets/download.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+  <polyline points="7 10 12 15 17 10"></polyline>
+  <line x1="12" y1="15" x2="12" y2="3"></line>
+</svg>

--- a/frontend/src/charts/ChartWrapper.jsx
+++ b/frontend/src/charts/ChartWrapper.jsx
@@ -11,6 +11,9 @@ import Fullscreen from '../assets/maximize.svg';
 import zoomIn from '../assets/zoom-in.svg';
 import zoomOut from '../assets/zoom-out.svg';
 import downsample from '../assets/downsample.svg';
+import downloadIcon from '../assets/download.svg';
+import GetAppIcon from '@mui/icons-material/GetApp';
+
 import {
   Chart as ChartJS,
   LineController,
@@ -250,7 +253,19 @@ function ChartWrapper({ id, data, options, stream }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scaleRef]);
 
+  const handleExportChart = () => {
+    if (chartRef.current) {
+      const link = document.createElement('a');
+      link.href = chartRef.current.toBase64Image();
+      link.download = `chart-${id}-${new Date().toISOString().split('T')[0]}.png`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  };
+
   return (
+    
     <Box
       sx={{
         display: 'flex',
@@ -424,6 +439,33 @@ function ChartWrapper({ id, data, options, stream }) {
             <Box component='img' src={downsample} sx={{ width: '16px', height: '16px' }}></Box>
           </ToggleButton>
         </Tooltip>
+        
+        <Tooltip
+          title='Export Chart'
+          placement='bottom'
+          disableInteractive
+          slotProps={{
+            popper: {
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, -11],
+                  },
+                },
+              ],
+            },
+          }}
+        >
+          <ToggleButton 
+            value={false} 
+            onClick={handleExportChart} 
+            sx={{ width: '32px', height: '32px' }}
+          >
+            <GetAppIcon sx={{ width: '16px', height: '16px' }} />
+          </ToggleButton>
+        </Tooltip>
+        
         <Tooltip
           title='Fullscreen'
           placement='bottom'
@@ -610,6 +652,29 @@ function ChartWrapper({ id, data, options, stream }) {
                     <Box component='img' src={downsample} sx={{ width: '20px', height: '20px' }}></Box>
                   </ToggleButton>
                 </Tooltip>
+                
+                <Tooltip
+                  title='Export Chart'
+                  placement='bottom'
+                  disableInteractive
+                  slotProps={{
+                    popper: {
+                      modifiers: [
+                        {
+                          name: 'offset',
+                          options: {
+                            offset: [0, -11],
+                          },
+                        },
+                      ],
+                    },
+                  }}
+                >
+                  <ToggleButton value={false} onClick={handleExportChart}>
+                    <Box component='img' src={downloadIcon} sx={{ width: '20px', height: '20px' }}></Box>
+                  </ToggleButton>
+                </Tooltip>
+                
                 <Tooltip
                   title='Windowed'
                   placement='bottom'

--- a/frontend/src/charts/__tests__/ChartWrapper.test.jsx
+++ b/frontend/src/charts/__tests__/ChartWrapper.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect,vi } from 'vitest';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -536,6 +536,20 @@ describe('loading charts', () => {
     const fullscreenBtnElement = await screen.findByLabelText(/Fullscreen/i);
     expect(fullscreenBtnElement).toBeInTheDocument();
   });
+
+  it('should render export button', async () => {
+    render(
+      <MockChartWrapper
+        id='vwc'
+        data={data}
+        streamChartOptions={streamChartOptions}
+        chartOptions={chartOptions}
+        stream={false}
+      />,
+    );
+    const exportBtnElement = await screen.findByLabelText(/Export Chart/i);
+    expect(exportBtnElement).toBeInTheDocument();
+  });
 });
 
 describe('testing side button events', () => {
@@ -720,5 +734,33 @@ describe('testing side button events', () => {
     await user.click(fullscreenBtnElement);
     fullscreenModalElement = await screen.queryByTestId(/^fullscreen-modal$/);
     expect(fullscreenModalElement).toBeInTheDocument();
+  });
+
+  it('should trigger chart export', async () => {
+    const user = userEvent.setup();
+    const createElementSpy = vi.spyOn(document, 'createElement');
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    const removeChildSpy = vi.spyOn(document.body, 'removeChild');
+    
+    render(
+      <MockChartWrapper
+        id='vwc'
+        data={data}
+        streamChartOptions={streamChartOptions}
+        chartOptions={chartOptions}
+        stream={false}
+      />,
+    );
+    
+    const exportBtnElement = await screen.findByLabelText(/Export Chart/i);
+    await user.click(exportBtnElement);
+    
+    expect(createElementSpy).toHaveBeenCalledWith('a');
+    expect(appendChildSpy).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalled();
+    
+    createElementSpy.mockRestore();
+    appendChildSpy.mockRestore();
+    removeChildSpy.mockRestore();
   });
 });


### PR DESCRIPTION
**Description**
This PR introduces a chart export function that enables users to export charts as PNG images. The export functionality uses Chart.js's built-in toBase64Image() method. This feature is helpful in sharing charts within reports, presentations, or communication channels without using screenshots.

**Changes Made**
- Added export button to chart controls sidebar
- Implemented handleExportChart function that renders the chart as a PNG image
- Added the export button on both regular view and fullscreen modal
- Implemented Material-UI's GetAppIcon on the regular view and a custom download icon on the fullscreen view

**How to Test**
1. Go to any page with charts
2. Click the download button in the chart controls sidebar
3. Check that the chart is downloaded as a PNG file with the naming format chart-[id]-[date].png

**Screenrecording**

https://github.com/user-attachments/assets/08cc01ca-57c6-4038-ba37-9b0dfd635197

**Related Issue**
Closes #384 




