### PR TITLE
Fix Authentication state handling in Map Page Nav bar

### DIFF
--- a/frontend/src/pages/map/Map.jsx
+++ b/frontend/src/pages/map/Map.jsx
@@ -1,9 +1,11 @@
-import React from 'react';
 import { Box } from '@mui/material';
-import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import React from 'react';
+import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
+import useAuth from '../../auth/hooks/useAuth';
 import Nav from '../../components/Nav';
 
 function Map() {
+  const { user, setUser, loggedIn, setLoggedIn } = useAuth();
   const styles = {
     leafletContainer: {
       width: '100%',
@@ -24,7 +26,7 @@ function Map() {
         backgroundColor: '#DAD7CD',
       }}
     >
-      <Nav />
+      <Nav user={user} setUser={setUser} loggedIn={loggedIn} setLoggedIn={setLoggedIn} />
       {/* MAP PAGE */}
       <MapContainer
         center={[36.95620689807501, -122.05855126777698]}


### PR DESCRIPTION
⚡ Key Changes:
- The Map page now uses the authentication state from the global context and passes it to the Nav bar.
- This ensures that account/profile/logout options only show when the user is logged in, matching the behavior of other main pages.

Tested locally to ensure correct Nav bar behavior for both logged-in and logged-out states.

<img width="1260" alt="Screenshot 2025-04-29 at 2 28 37 PM" src="https://github.com/user-attachments/assets/37272a41-6cfc-4d59-ac4d-00e724f503c9" />


cc @jmadden173 @aleclevy 