### PR TITLE
Minor Fix

### DIFF
--- a/frontend/src/pages/dashboard/components/DropList/DropList.css
+++ b/frontend/src/pages/dashboard/components/DropList/DropList.css
@@ -24,6 +24,8 @@
   flex-direction: column;
   gap: 70px;
   min-height: 200px;
-  /* Remove overflow-y to prevent z-index issues */
+  overflow-y: auto; /* Reintroduce vertical scrolling */
+  overflow-x: hidden;
   position: relative;
+  z-index: 1; /* Ensure the z-index is set to keep the dragged item visible */
 }


### PR DESCRIPTION
## Description
### Problem
The archive modal was missing vertical scrolling, which made it difficult to navigate through a large number of items. Additionally, there was a z-index issue causing dragged items to disappear behind other elements.

### Solution
- Reintroduced vertical scrolling.
- Ensured dragged items remain visible.
- Verified that vertical scrolling is functional.
- Confirmed that dragged items stay visible during drag operations.
- Checked that archive/unarchive functionality still works correctly.

### Impact
These changes improve the user experience by making the drag-and-drop functionality more intuitive and visually appealing, especially when dealing with a large number of items in the archive modal.

### Screen-recording
https://github.com/user-attachments/assets/21ed18e7-2366-4925-839e-0b4e259db313

### Closes #425 

