### PR TITLE
Enabled Cell Data Editing on Profile Page

### DIFF
--- a/backend/api/resources/cell.py
+++ b/backend/api/resources/cell.py
@@ -52,8 +52,8 @@ class Cell(Resource):
 
     def put(self, cellId):
         json_data = request.json
-        #print("Received payload:", json_data)
-        #archive = json_data.get("archive")
+        # print("Received payload:", json_data)
+        # archive = json_data.get("archive")
         cell = CellModel.get(cellId)
 
         if cell:
@@ -77,6 +77,5 @@ class Cell(Resource):
         if not cell:
             return jsonify({"message": "Cell not found"}), 404
         cell.delete()
-        
-        return {"message": "Cell deleted successfully"}
 
+        return {"message": "Cell deleted successfully"}

--- a/backend/api/resources/cell.py
+++ b/backend/api/resources/cell.py
@@ -52,7 +52,7 @@ class Cell(Resource):
 
     def put(self, cellId):
         json_data = request.json
-        print("Received payload:", json_data)
+        #print("Received payload:", json_data)
         #archive = json_data.get("archive")
         cell = CellModel.get(cellId)
 
@@ -67,6 +67,7 @@ class Cell(Resource):
                 cell.longitude = json_data.get("long")
             if "archive" in json_data:
                 cell.archive = json_data.get("archive")
+
             cell.save()
             return {"message": "Successfully updated cell"}
         return jsonify({"message": "Cell not found"}), 404
@@ -76,4 +77,6 @@ class Cell(Resource):
         if not cell:
             return jsonify({"message": "Cell not found"}), 404
         cell.delete()
+        
         return {"message": "Cell deleted successfully"}
+

--- a/backend/api/resources/cell.py
+++ b/backend/api/resources/cell.py
@@ -52,10 +52,21 @@ class Cell(Resource):
 
     def put(self, cellId):
         json_data = request.json
-        archive = json_data.get("archive")
+        print("Received payload:", json_data)
+        #archive = json_data.get("archive")
         cell = CellModel.get(cellId)
+
         if cell:
-            cell.archive = archive
+            if "name" in json_data:
+                cell.name = json_data.get("name")
+            if "location" in json_data:
+                cell.location = json_data.get("location")
+            if "lat" in json_data:
+                cell.latitude = json_data.get("lat")
+            if "long" in json_data:
+                cell.longitude = json_data.get("long")
+            if "archive" in json_data:
+                cell.archive = json_data.get("archive")
             cell.save()
             return {"message": "Successfully updated cell"}
         return jsonify({"message": "Cell not found"}), 404

--- a/backend/tests/test_cell.py
+++ b/backend/tests/test_cell.py
@@ -20,6 +20,7 @@ from api import db
 #         b'"latitude": 2.0, "userEmail": "", "archive": false}]\n'
 #     )
 
+
 def test_update_cell_endpoint(test_client, setup_cells):
     # Grab the first inserted test cell
     cell = db.session.query(Cell).filter_by(name="cell_1").first()

--- a/backend/tests/test_cell.py
+++ b/backend/tests/test_cell.py
@@ -1,3 +1,6 @@
+from api.models.cell import Cell
+from api import db
+
 # Broken test; authenticate in cell.py dosent work for this test
 #
 #
@@ -16,6 +19,23 @@
 #         b'{"name": "cell_2", "location": "", "longitude": 2.0, '
 #         b'"latitude": 2.0, "userEmail": "", "archive": false}]\n'
 #     )
+
+def test_update_cell_endpoint(test_client, setup_cells):
+    # Grab the first inserted test cell
+    cell = db.session.query(Cell).filter_by(name="cell_1").first()
+    assert cell is not None
+
+    update_data = {
+        "name": "updated_cell",
+        "location": "updated_location",
+        "lat": 10.0,
+        "long": 20.0,
+        "archive": True,
+    }
+
+    response = test_client.put(f"/api/cell/{cell.id}", json=update_data)
+    assert response.status_code == 200
+    assert response.json.get("message") == "Successfully updated cell"
 
 
 # FIXME:

--- a/frontend/src/__tests__/Profile.test.jsx
+++ b/frontend/src/__tests__/Profile.test.jsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // import AccountInfo from '../pages/profile/components/AccountInfo';
 import DeleteCellModal from '../pages/profile/components/DeleteCellModal';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { getCells, deleteCell, getUserCells } from '../services/cell';
+import { updateCell, getCells, deleteCell, getUserCells } from '../services/cell';
 import { useOutletContext } from 'react-router-dom';
 import axios from 'axios';
 vi.mock('axios');
@@ -248,6 +248,46 @@ describe('DeleteCellModal component', () => {
     expect(screen.queryByText('Delete Cell ')).toBeNull();
   });
 });
+
+describe('updateCell', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('successfully updates a cell', async () => {
+    const mockCellId = 42;
+    const mockUpdatedData = { name: 'New Cell Name', location: 'Updated Location', lat: '12.34', long: '56.78' };
+    const mockResponse = { id: mockCellId, ...mockUpdatedData };
+
+    axios.put.mockResolvedValueOnce({ data: mockResponse });
+
+    const result = await updateCell(mockCellId, mockUpdatedData);
+
+    expect(axios.put).toHaveBeenCalledWith(
+      expect.stringContaining(`/api/cell/${mockCellId}`),
+      mockUpdatedData,
+      expect.any(Object)
+    );
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('throws an error when the update fails', async () => {
+    const mockCellId = 42;
+    const mockUpdatedData = { name: 'Bad Cell Update' };
+    const mockError = {
+      response: {
+        data: { error: 'Update failed' },
+      },
+    };
+
+    axios.put.mockRejectedValueOnce(mockError);
+
+    await expect(updateCell(mockCellId, mockUpdatedData)).rejects.toThrow();
+    expect(axios.put).toHaveBeenCalled();
+  });
+});
+
+
 
 describe('Cell Service API Functions', () => {
   afterEach(() => {

--- a/frontend/src/pages/profile/components/AddCellModal.jsx
+++ b/frontend/src/pages/profile/components/AddCellModal.jsx
@@ -156,7 +156,7 @@ function AddCellModal() {
                 Here&apos;,s the endpoint to start uploading teros data, https://dirtviz.jlab.ucsc.edu/api/teros/
                 {response.id}
               </p>
-              <Button onClick={DoneButtonClose}>Done</Button>
+              <Button onClick={handleClose}>Done</Button>
             </>
           )}
         </Box>

--- a/frontend/src/pages/profile/components/AddCellModal.jsx
+++ b/frontend/src/pages/profile/components/AddCellModal.jsx
@@ -17,16 +17,16 @@ function AddCellModal() {
   const [lat, setLat] = useState('');
   const archive = false;
   const [response, setResponse] = useState(null);
-  const [setCloseDonebutton] = useState(true);
+  // const [setCloseDonebutton] = useState(true);
   const handleOpen = () => {
     setOpen(true);
     setResponse(null);
   };
 
-  const DoneButtonClose = () => {
-    setCloseDonebutton(false);
-    setOpen(false);
-  };
+  // const DoneButtonClose = () => {
+  //   setCloseDonebutton(false);
+  //   setOpen(false);
+  // };
 
   const handleClose = () => setOpen(false);
   useEffect(() => {

--- a/frontend/src/pages/profile/components/CellsList.jsx
+++ b/frontend/src/pages/profile/components/CellsList.jsx
@@ -4,6 +4,7 @@ import { DataGrid } from '@mui/x-data-grid';
 import { useOutletContext } from 'react-router-dom';
 import AddCellModal from './AddCellModal';
 import DeleteCellModal from './DeleteCellModal';
+import EditCellModal from './EditCellModal';
 
 function CellsList() {
   let data = useOutletContext();
@@ -32,6 +33,9 @@ function CellsList() {
     { field: 'lat', headerName: 'Latitude', width: 150 },
     { field: 'long', headerName: 'Longitude', width: 150 },
     { field: 'archive', headerName: 'Archive', width: 150 },
+    { field: 'edit', headerName: 'Edit', width: 100, 
+      renderCell: (params) => (<EditCellModal cell={params.row} />) // edit button in new column
+    }
   ];
 
   let rows = [];

--- a/frontend/src/pages/profile/components/CellsList.jsx
+++ b/frontend/src/pages/profile/components/CellsList.jsx
@@ -33,7 +33,7 @@ function CellsList() {
     { field: 'lat', headerName: 'Latitude', width: 150 },
     { field: 'long', headerName: 'Longitude', width: 150 },
     { field: 'archive', headerName: 'Archive', width: 150 },
-    { field: 'edit', headerName: 'Edit', width: 100, 
+    { field: '', headerName: '', width: 85,   sortable: false, filterable: false, disableColumnMenu: true,
       renderCell: (params) => (<EditCellModal cell={params.row} />) // edit button in new column
     }
   ];

--- a/frontend/src/pages/profile/components/EditCellModal.jsx
+++ b/frontend/src/pages/profile/components/EditCellModal.jsx
@@ -76,12 +76,10 @@ function EditCellModal({ cell }) {
           }}
         >
           {!response ? (
-            
             <>
               <Typography id="edit-cell-modal-title" variant="h6" component="h2" gutterBottom>
                 Edit Cell {cell.id} Info
               </Typography>
-
               <TextField
                 label="Name"
                 value={formData.name}
@@ -90,9 +88,7 @@ function EditCellModal({ cell }) {
                 margin="normal"
                 required
                 error={formData.name?.length === 0}
-
               />
-
               <TextField
                 label="Location"
                 value={formData.location}
@@ -101,7 +97,6 @@ function EditCellModal({ cell }) {
                 margin="normal"
                 required
                 error={formData.location?.length === 0}
-
               />
                 <TextField
                   label="Longitude"
@@ -114,7 +109,6 @@ function EditCellModal({ cell }) {
                   error={formData.long?.length === 0 || isNaN(Number(formData.long))}
                   helperText={isNaN(Number(formData.long)) ? 'Please Enter Numbers' : ''}
                 />
-
                 <TextField
                   label="Latitude"
                   variant="outlined"
@@ -125,7 +119,6 @@ function EditCellModal({ cell }) {
                   required
                   error={formData.lat?.length === 0 || isNaN(Number(formData.lat))}
                   helperText={isNaN(Number(formData.lat)) ? 'Please Enter Numbers' : ''}
-
                 />
 
               {/* following AccountInfo styling */}
@@ -176,3 +169,4 @@ function EditCellModal({ cell }) {
 }
 
 export default EditCellModal;
+

--- a/frontend/src/pages/profile/components/EditCellModal.jsx
+++ b/frontend/src/pages/profile/components/EditCellModal.jsx
@@ -3,6 +3,7 @@ import { Modal, Box, Typography, Button, IconButton, TextField } from '@mui/mate
 import CloseIcon from '@mui/icons-material/Close';
 import { useOutletContext } from 'react-router-dom';
 import { updateCell } from '../../../services/cell';
+import PropTypes from 'prop-types';
 
 function EditCellModal({ cell }) {
   const data = useOutletContext();
@@ -36,7 +37,7 @@ function EditCellModal({ cell }) {
     //   setSubmitting(false);
     // }, 1000);
     
-    // backend request not yet implemented - TO DO
+    // backend request implemented - DONE
     updateCell(cell.id, formData)
       .then((res) => {
         setResponse(res);
@@ -170,3 +171,13 @@ function EditCellModal({ cell }) {
 
 export default EditCellModal;
 
+// expected prop types for EditCellModal - prop validation
+EditCellModal.propTypes = {
+  cell: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    name: PropTypes.string.isRequired,
+    location: PropTypes.string.isRequired,
+    long: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    lat: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  }).isRequired,
+};

--- a/frontend/src/pages/profile/components/EditCellModal.jsx
+++ b/frontend/src/pages/profile/components/EditCellModal.jsx
@@ -1,0 +1,178 @@
+import React, { useState } from 'react';
+import { Modal, Box, Typography, Button, IconButton, TextField } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { useOutletContext } from 'react-router-dom';
+import { updateCell } from '../../../services/cell';
+
+function EditCellModal({ cell }) {
+  const data = useOutletContext();
+  const refetch = data[3];
+
+  const [isOpen, setOpen] = useState(false);
+  const [formData, setFormData] = useState({ ...cell });
+  const [response, setResponse] = useState(null);
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+    setResponse(null);
+    setFormData({ ...cell });
+  };
+
+  const handleClose = () => setOpen(false);
+
+  const handleChange = (field) => (e) => {
+    setFormData({ ...formData, [field]: e.target.value });
+  };
+
+  const handleSubmit = () => {
+    setSubmitting(true);
+
+    // simulate a successful request
+    // setTimeout(() => {
+    //   const fakeResponse = { success: true, data: formData };
+    //   setResponse(fakeResponse);
+    //   refetch();
+    //   setSubmitting(false);
+    // }, 1000);
+    
+    // backend request not yet implemented - TO DO
+    updateCell(cell.id, formData)
+      .then((res) => {
+        setResponse(res);
+        refetch();
+      })
+      .catch((err) => console.error('Edit failed:', err))
+      .finally(() => setSubmitting(false));
+    
+  };
+
+  return (
+    <>
+      {/* copied account edit profile button styling */}
+      <Button variant="contained" onClick={handleOpen} 
+        sx={{ backgroundColor: '#588157', 
+        '&:hover': { backgroundColor: '#3a5a40' } }}>
+        Edit
+      </Button>
+
+      <Modal open={isOpen} onClose={handleClose} aria-labelledby="edit-cell-modal-title">
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: 400,
+            bgcolor: 'background.paper',
+            borderRadius: '12px',
+            boxShadow: 24,
+            p: 4,
+          }}
+          component="form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+        >
+          {!response ? (
+            
+            <>
+              <Typography id="edit-cell-modal-title" variant="h6" component="h2" gutterBottom>
+                Edit Cell {cell.id} Info
+              </Typography>
+
+              <TextField
+                label="Name"
+                value={formData.name}
+                onChange={handleChange('name')}
+                fullWidth
+                margin="normal"
+                required
+                error={formData.name?.length === 0}
+
+              />
+
+              <TextField
+                label="Location"
+                value={formData.location}
+                onChange={handleChange('location')}
+                fullWidth
+                margin="normal"
+                required
+                error={formData.location?.length === 0}
+
+              />
+                <TextField
+                  label="Longitude"
+                  variant="outlined"
+                  value={formData.long || ''}
+                  onChange={handleChange('long')}
+                  fullWidth
+                  margin="normal"
+                  required
+                  error={formData.long?.length === 0 || isNaN(Number(formData.long))}
+                  helperText={isNaN(Number(formData.long)) ? 'Please Enter Numbers' : ''}
+                />
+
+                <TextField
+                  label="Latitude"
+                  variant="outlined"
+                  value={formData.lat || ''}
+                  onChange={handleChange('lat')}
+                  fullWidth
+                  margin="normal"
+                  required
+                  error={formData.lat?.length === 0 || isNaN(Number(formData.lat))}
+                  helperText={isNaN(Number(formData.lat)) ? 'Please Enter Numbers' : ''}
+
+                />
+
+              {/* following AccountInfo styling */}
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 3, gap: 2 }}>
+                <Button
+                  onClick={handleClose}
+                  disabled={isSubmitting}
+                  sx={{
+                    color: '#6C757D',
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled={isSubmitting}
+                  sx={{
+                    backgroundColor: '#588157',
+                    '&:hover': {
+                      backgroundColor: '#3a5a40',
+                    },
+                  }}
+                >
+                  Edit Cell
+                </Button>
+              </Box>
+            </>
+          ) : (
+            <>
+              <IconButton
+                sx={{ position: 'absolute', top: 5, right: 5 }}
+                aria-label='close'
+                size='small'
+                onClick={handleClose}
+              >
+                <CloseIcon fontSize='small' />
+              </IconButton>
+              <h1>Cell Edited</h1>
+              <p>The cell with ID {cell.id} has been successfully edited.</p>
+              <Button onClick={handleClose}>Done</Button>
+            </>
+          )}
+        </Box>
+      </Modal>
+    </>
+  );
+}
+
+export default EditCellModal;

--- a/frontend/src/services/cell.js
+++ b/frontend/src/services/cell.js
@@ -40,6 +40,7 @@ export const addCell = (cellName, location, longitude, latitude, archive, email)
 export const updateCell = async (cellId, updatedData) => {
   const url = `${process.env.PUBLIC_URL}/api/cell/${cellId}`;
   try {
+    console.log('Sending payload', updatedData);
     const response = await axios.put(url, updatedData, {
       headers: { 'Content-Type': 'application/json' },
     });

--- a/frontend/src/services/cell.js
+++ b/frontend/src/services/cell.js
@@ -42,8 +42,8 @@ export const updateCell = async (cellId, updatedData) => {
   try {
     //console.log('Sending payload', updatedData);
     const response = await axios.put(url, updatedData, { headers: { 'Content-Type': 'application/json' }});
-    
     return response.data;
+    
   } catch (error) {
     console.error('Error updating cell:', error.response ? error.response.data : error.message);
     throw error;

--- a/frontend/src/services/cell.js
+++ b/frontend/src/services/cell.js
@@ -36,6 +36,21 @@ export const addCell = (cellName, location, longitude, latitude, archive, email)
     });
 };
 
+// used to edit cell data in the table with put request - BACKEND NOT YET IMPLEMENTED
+export const updateCell = async (cellId, updatedData) => {
+  const url = `${process.env.PUBLIC_URL}/api/cell/${cellId}`;
+  try {
+    const response = await axios.put(url, updatedData, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error updating cell:', error.response ? error.response.data : error.message);
+    throw error;
+  }
+};
+
+
 export const deleteCell = async (cellId) => {
   // Show confirmation dialog before proceeding with deletion
   const confirmDelete = window.confirm('Are you sure you want to delete this cell?');

--- a/frontend/src/services/cell.js
+++ b/frontend/src/services/cell.js
@@ -40,10 +40,9 @@ export const addCell = (cellName, location, longitude, latitude, archive, email)
 export const updateCell = async (cellId, updatedData) => {
   const url = `${process.env.PUBLIC_URL}/api/cell/${cellId}`;
   try {
-    console.log('Sending payload', updatedData);
-    const response = await axios.put(url, updatedData, {
-      headers: { 'Content-Type': 'application/json' },
-    });
+    //console.log('Sending payload', updatedData);
+    const response = await axios.put(url, updatedData, { headers: { 'Content-Type': 'application/json' }});
+    
     return response.data;
   } catch (error) {
     console.error('Error updating cell:', error.response ? error.response.data : error.message);


### PR DESCRIPTION
### Description
This PR resolves issue #347 by allowing users to edit a cell’s name, location, latitude, and longitude info directly from the profile page dashboard.

### Changes
- Updated the backend `PUT /api/cell/<cellId>` route to support partial updates to cell fields.
- Hooked up the frontend `EditCellModal `to call the updated endpoint on submit.
- Added a dedicated Edit button to each row in the cell table for quick access.
- Handled frontend validation for numeric fields and missing data.

### Impact
This improves the overall usability and efficiency of the cell management UI, making it easier to correct or update cell data without leaving the page, therefore enhancing the UI/UX.