### PR TITLE
TTN Integration with logger api endpoint

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -24,6 +24,8 @@ class Config(object):
     SESSION_PERMANENT = False
     SESSION_USE_SIGNER = True
     SESSION_REDIS = redis.from_url("redis://redis:6379")
+    TTN_API_KEY = os.getenv("TTN_API_KEY")
+    TTN_APP_ID = os.getenv("TTN_APP_ID")
 
 
 class ProductionConfig(Config):

--- a/backend/api/ttn/README.md
+++ b/backend/api/ttn/README.md
@@ -1,0 +1,3 @@
+# The Things Network Integration
+
+

--- a/backend/api/ttn/end_devices.py
+++ b/backend/api/ttn/end_devices.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import os
 from enum import Enum
 import warnings
 
@@ -96,7 +97,32 @@ class EndDevice:
 class TTNApi:
     """High level interface for The Things Network API."""
 
-    def __init__(self, api_key: str, app_id: str):
+    def __init__(self, api_key: str = "", app_id: str = ""):
+        """ Initialize the TTNApi.
+
+        The param `api_key` is used to override the env variables
+        `TTN_API_KEY`. Similarly the `app_id` is used to override the
+        environment variable `TTN_APP_ID`. If the parameters are not set,
+
+        Args:
+            api_key: The API key for authentication.
+            app_id: The application ID to associate with the End Devices.
+        """
+
+        if api_key == "":
+            api_key_env = os.getenv("TTN_API_KEY")
+            if api_key_env is None:
+                raise ValueError("TTN_API_KEY environment variable is not set.")
+            else:
+                api_key = api_key_env
+
+        if app_id == "":
+            app_id_env = os.getenv("TTN_APP_ID")
+            if app_id_env is None:
+                raise ValueError("TTN_APP_ID environment variable is not set.")
+            else:
+                app_id = app_id_env
+
         self.end_device_reg = EndDeviceRegistry(api_key, app_id)
         self.js_device_reg = JoinServerDeviceRegistry(api_key, app_id)
 
@@ -166,9 +192,13 @@ class TTNApi:
 
         deleted = True
 
+        # delete from device registry
         deleted = self.end_device_reg.delete(end_device)
         if not deleted and not force:
             return False
+
+        # delete from join server
+
 
         # always return true if force is set
         if force:

--- a/backend/tests/test_ttn.py
+++ b/backend/tests/test_ttn.py
@@ -95,7 +95,6 @@ def test_update_end_device():
     assert updated is True
 
 
-@pytest.mark.filterwarnings("ignore:ttn")
 def test_delete_end_device():
     """Test deleting an End Device in the TTN registry."""
 
@@ -112,7 +111,19 @@ def test_delete_end_device():
 
     assert deleted is True
 
-    # test deleting an end device that does NOT exist
+
+@pytest.mark.filterwarnings("ignore:ttn")
+def test_delete_end_device_not_found():
+    """Test deleting an End Device that does not exist in the TTN registry."""
+
+    data = {
+        "ids": {
+            "device_id": "non-existent-device",
+        },
+    }
+
+    end_device = EndDevice(data)
+
     deleted = api.delete_end_device(end_device)
 
     assert deleted is False

--- a/backend/tests/test_ttn.py
+++ b/backend/tests/test_ttn.py
@@ -39,12 +39,60 @@ def test_create_end_device():
 def test_get_end_device():
     """Test retrieving an End Device from the TTN registry."""
 
-    pass
+    data = {
+        "ids": {
+            "device_id": "dirtviz-unit-test",
+        },
+    }
+
+    end_device = EndDevice(data)
+
+    end_device = api.get_end_device(end_device)
+
+    assert end_device is not None
+    assert end_device.data["ids"]["device_id"] == "dirtviz-unit-test"
+    assert end_device.data["ids"]["dev_eui"] == "0080E1150546D093"
+    assert end_device.data["ids"]["join_eui"] == "0101010101010101"
+
+
+def test_get_all_end_device():
+    """Test retrieving all End Devices from the TTN registry."""
+    
+    end_devices = api.get_all_end_devices()
+
+    assert len(end_devices) > 0
+
+def test_get_list_end_device():
+    """Test retrieving an End Device from the TTN registry."""
+
+    # get a list of all end devices
+    end_devices = api.get_end_device_list()
+    assert len(end_devices) > 0
+
+    # get a list of end devices with a specific device ID
+    # NOTE: This is not functional because I don't understnad how the filtering
+    # mechanism works in the TTN API. Just get by a specific device ID for now.
+    #filters = { "device_id": "dirtviz-unit-test", }
+
+    #end_devices = api.get_end_device_list(filters=filters)
+    #assert len(end_devices) == 1
+
+
 
 def test_update_end_device():
     """Test updating an End Device in the TTN registry."""
 
-    pass
+    data = {
+        "description": "Unit tests update description",
+        "ids": {
+            "device_id": "dirtviz-unit-test",
+        },
+    }
+
+    end_device = EndDevice(data)
+    updated = api.update_end_device(end_device)
+
+    assert updated is True
 
 @pytest.mark.filterwarnings("ignore:ttn")
 def test_delete_end_device():

--- a/backend/tests/test_ttn.py
+++ b/backend/tests/test_ttn.py
@@ -5,7 +5,7 @@ import pytest
 # global API
 api = TTNApi(
     "",
-    "soil-power-sensor"
+    "soil-power-sensor",
 )
 
 def test_create_end_device():
@@ -36,6 +36,7 @@ def test_create_end_device():
     assert "created_at" in end_device.data
     assert "updated_at" in end_device.data
 
+
 def test_get_end_device():
     """Test retrieving an End Device from the TTN registry."""
 
@@ -57,10 +58,11 @@ def test_get_end_device():
 
 def test_get_all_end_device():
     """Test retrieving all End Devices from the TTN registry."""
-    
+
     end_devices = api.get_all_end_devices()
 
     assert len(end_devices) > 0
+
 
 def test_get_list_end_device():
     """Test retrieving an End Device from the TTN registry."""
@@ -72,11 +74,10 @@ def test_get_list_end_device():
     # get a list of end devices with a specific device ID
     # NOTE: This is not functional because I don't understnad how the filtering
     # mechanism works in the TTN API. Just get by a specific device ID for now.
-    #filters = { "device_id": "dirtviz-unit-test", }
+    # filters = { "device_id": "dirtviz-unit-test", }
 
-    #end_devices = api.get_end_device_list(filters=filters)
-    #assert len(end_devices) == 1
-
+    # end_devices = api.get_end_device_list(filters=filters)
+    # assert len(end_devices) == 1
 
 
 def test_update_end_device():
@@ -93,6 +94,7 @@ def test_update_end_device():
     updated = api.update_end_device(end_device)
 
     assert updated is True
+
 
 @pytest.mark.filterwarnings("ignore:ttn")
 def test_delete_end_device():

--- a/backend/tests/test_ttn.py
+++ b/backend/tests/test_ttn.py
@@ -11,15 +11,35 @@ def test_create_end_device():
     """Test creating an End Device in the TTN registry."""
 
     data = {
-        "name": "Dirtviz Unit Test",
+        # general requirements 
         "ids": {
             "device_id": "dirtviz-unit-test",
             "dev_eui": "0080E1150546D093",
             "join_eui": "0101010101010101",
         },
-        "lorawan_version": EndDevice.MACVersion.MAC_V1_0_3.value,
-        "lorawan_phy_version": EndDevice.PHYVersion.RP001_V1_0_3_REV_A.value,
+        "network_server_address": "nam1.cloud.thethings.network",
+        "application_server_address": "nam1.cloud.thethings.network",
+        "join_server_address": "nam1.cloud.thethings.network",
+        # end device registry
+        "name": "Dirtviz Unit Test",
+        # network server
+        "lorawan_version": "MAC_V1_0_3",
+        "lorawan_phy_version": "PHY_V1_0_3_REV_A",
         "frequency_plan_id": "US_902_928_FSB_2",
+        "mac_settings": {
+            "rx2_data_rate_index": 8,
+            "rx2_frequency": 923300000,
+        },
+        "supports_join": True,
+        "multicast": False,
+        "supports_class_b": False,
+        "supports_class_c": False,
+        # required for js
+        "root_keys": {
+            "app_key": {
+                "key": "CEC24E6A258B2B20A5A7C05ABD2C1724",
+            },
+        },
     }
 
     end_device = EndDevice(data)

--- a/backend/tests/test_ttn.py
+++ b/backend/tests/test_ttn.py
@@ -1,0 +1,69 @@
+from api.ttn.end_devices import EndDevice, TTNApi
+
+import pytest
+
+# global API
+api = TTNApi(
+    "",
+    "soil-power-sensor"
+)
+
+def test_create_end_device():
+    """Test creating an End Device in the TTN registry."""
+
+    data = {
+        "name": "Dirtviz Unit Test",
+        "ids": {
+            "device_id": "dirtviz-unit-test",
+            "dev_eui": "0080E1150546D093",
+            "join_eui": "0101010101010101",
+        },
+        "lorawan_version": EndDevice.MACVersion.MAC_V1_0_3.value,
+        "lorawan_phy_version": EndDevice.PHYVersion.RP001_V1_0_3_REV_A.value,
+        "frequency_plan_id": "US_902_928_FSB_2",
+    }
+
+    end_device = EndDevice(data)
+
+    end_device = api.register_end_device(end_device)
+
+    assert end_device is not None
+    assert end_device.data["name"] == "Dirtviz Unit Test"
+    assert "ids" in end_device.data
+    assert end_device.data["ids"]["device_id"] == "dirtviz-unit-test"
+    assert end_device.data["ids"]["dev_eui"] == "0080E1150546D093"
+    assert end_device.data["ids"]["join_eui"] == "0101010101010101"
+    assert "created_at" in end_device.data
+    assert "updated_at" in end_device.data
+
+def test_get_end_device():
+    """Test retrieving an End Device from the TTN registry."""
+
+    pass
+
+def test_update_end_device():
+    """Test updating an End Device in the TTN registry."""
+
+    pass
+
+@pytest.mark.filterwarnings("ignore:ttn")
+def test_delete_end_device():
+    """Test deleting an End Device in the TTN registry."""
+
+    data = {
+        "ids": {
+            "device_id": "dirtviz-unit-test",
+        },
+    }
+
+    end_device = EndDevice(data)
+
+    # test deleting an end device that exists
+    deleted = api.delete_end_device(end_device)
+
+    assert deleted is True
+
+    # test deleting an end device that does NOT exist
+    deleted = api.delete_end_device(end_device)
+
+    assert deleted is False

--- a/backend/tests/test_ttn.py
+++ b/backend/tests/test_ttn.py
@@ -2,10 +2,9 @@ from api.ttn.end_devices import EndDevice, TTNApi
 
 import pytest
 
-# global API
+# global API instance
 api = TTNApi(
-    "",
-    "soil-power-sensor",
+    app_id = "soil-power-sensor",
 )
 
 def test_create_end_device():


### PR DESCRIPTION
Adds support for registering new devices with The Things Network. Created the necessary endpoints to create and delete end devices. Only implemented support for modifying end devices with the `EndDeviceRegistry`. That means we can change the name/description, but not able to change any network parameters of the devices. Adds a new env vars `TTN_API_KEY` and `TTN_APP_ID` that will need to be set for it to function.

WIP: Implemented basic `/logger/` endpoints. Did not implement any of the function calls to create new loggers in the db. I'm passing that off as part of #366 / #373 ?

Need to update:
- [ ] Env vars for ecs