### PR TITLE
Catches decode/processing failures in sensor ingest

### DIFF
--- a/backend/api/resources/sensor_data.py
+++ b/backend/api/resources/sensor_data.py
@@ -72,22 +72,25 @@ class SensorData(Resource):
             Response indicating success or failure. See util.process_measurement
             for full description.
         """
-        content_type = request.headers.get("Content-Type")
+        # Use mimetype so "application/json; charset=utf-8" still matches.
+        mimetype = request.mimetype
 
         # response to request
         resp = None
 
-        if content_type == "application/json":
+        if mimetype == "application/json":
             # get uplink json
             uplink_json = request.json
             resp = self.handle_ttn(uplink_json)
-        elif content_type == "application/octet-stream":
+        elif mimetype == "application/octet-stream":
             # get uplink binary data
             data = request.data
             resp = self.handle_binary(data)
         else:
-            err_str = f"Content-Type header of '{content_type}' incorrect"
-            raise ValueError(err_str)
+            resp = Response()
+            resp.status_code = 400
+            raw_ct = request.headers.get("Content-Type")
+            resp.data = f"Unsupported Content-Type: {raw_ct}"
         return resp
 
     @staticmethod
@@ -138,10 +141,8 @@ class SensorData(Resource):
             for full description.
         """
 
-        content_type = request.headers.get("Content-Type")
-
-        # check for correct content type and get json
-        if content_type == "application/octet-stream":
+        # Use mimetype so charset suffixes on Content-Type still match.
+        if request.mimetype == "application/octet-stream":
             # get uplink json
             data = request.data
         else:

--- a/backend/api/resources/sensor_data_json.py
+++ b/backend/api/resources/sensor_data_json.py
@@ -8,7 +8,7 @@ Authors:
 - Alec Levy <aleclevy3@gmail.com>
 """
 
-from flask import request, jsonify
+from flask import request, jsonify, Response
 from flask_restful import Resource
 
 from .util import process_measurement_json
@@ -52,18 +52,19 @@ class SensorData_Json(Resource):
             Response indicating success or failure. See util.process_measurement
             for full description.
         """
-        content_type = request.headers.get("Content-Type")
+        # Use mimetype so "application/json; charset=utf-8" still matches.
+        mimetype = request.mimetype
 
         # response to request
         resp = None
 
-        if content_type == "application/json":
-            # get uplink binary data
-            # data = request.json
+        if mimetype == "application/json":
             resp = self.handle_json(request)
         else:
-            err_str = f"Content-Type header of '{content_type}' incorrect"
-            raise ValueError(err_str)
+            resp = Response()
+            resp.status_code = 400
+            raw_ct = request.headers.get("Content-Type")
+            resp.data = f"Unsupported Content-Type: {raw_ct}"
         return resp
 
     @staticmethod
@@ -76,14 +77,13 @@ class SensorData_Json(Resource):
             for full description.
         """
 
-        content_type = request.headers.get("Content-Type")
-
-        # check for correct content type and get json
-        if content_type == "application/json":
-            # get uplink json
+        if request.mimetype == "application/json":
             data = request.json
         else:
-            raise ValueError("POST request must be application/json")
+            resp = Response()
+            resp.status_code = 400
+            resp.data = "POST request must be application/json"
+            return resp
 
         # decode and insert into db
         resp = process_measurement_json(data)

--- a/backend/api/resources/util.py
+++ b/backend/api/resources/util.py
@@ -90,7 +90,9 @@ def process_generic_measurement_json(meas: dict) -> Response:
                         if has_subscribers:
                             count = len(has_subscribers)
                             logger.debug(
-                                "SocketIO emitted to %s: %d subscribers", room_name, count
+                                "SocketIO emitted to %s: %d subscribers",
+                                room_name,
+                                count,
                             )
                 except Exception as e:
                     logger.error("SocketIO error emitting measurement: %s", e)
@@ -338,7 +340,11 @@ def process_measurement_dict(meas: dict):
                     )
                     if has_subscribers:
                         count = len(has_subscribers)
-                        logger.debug("SocketIO emitted to %s: %d subscribers", room_name, count)
+                        logger.debug(
+                            "SocketIO emitted to %s: %d subscribers",
+                            room_name,
+                            count,
+                        )
             except Exception as e:
                 logger.error("SocketIO error emitting measurement: %s", e)
 

--- a/backend/api/resources/util.py
+++ b/backend/api/resources/util.py
@@ -3,6 +3,7 @@
 author: John Madden <jmadden173@pm.me>
 """
 
+import logging
 import os
 from datetime import datetime
 
@@ -15,6 +16,8 @@ from ..models.power_data import PowerData
 from ..models.teros_data import TEROSData
 from ..models.sensor import Sensor
 from .. import socketio
+
+logger = logging.getLogger(__name__)
 
 DEBUG_SOCKETIO = os.getenv("DEBUG_SOCKETIO", "False").lower() == "true"
 
@@ -86,11 +89,11 @@ def process_generic_measurement_json(meas: dict) -> Response:
                         ).get(room_name)
                         if has_subscribers:
                             count = len(has_subscribers)
-                            print(
-                                f"[socketio] emitted to {room_name}:{count} subscribers"
+                            logger.debug(
+                                "SocketIO emitted to %s: %d subscribers", room_name, count
                             )
                 except Exception as e:
-                    print(f"[socketio] error emitting measurement: {e}")
+                    logger.error("SocketIO error emitting measurement: %s", e)
 
     resp = Response()
     resp.status_code = 200
@@ -121,7 +124,7 @@ def process_generic_measurement(data: bytes) -> Response:
     return process_generic_measurement_json(meas["measurements"])
 
 
-def process_measurement(data: bytes):
+def process_measurement(data: bytes) -> Response:
     """Process protobuf encoded measurement
 
     The byte string gets decoded through protobuf and inserted into the
@@ -137,12 +140,26 @@ def process_measurement(data: bytes):
         Flask response with status code and protobuf encoded response.
     """
 
-    # decode binary protobuf data
-    meas = decode_measurement(data, raw=False)
-    return process_measurement_dict(meas)
+    try:
+        meas = decode_measurement(data, raw=False)
+    except Exception as e:
+        logger.warning("Failed to decode measurement: %s", e)
+        resp = Response()
+        resp.status_code = 400
+        resp.data = f"Error decoding measurement: {e}"
+        return resp
+
+    try:
+        return process_measurement_dict(meas)
+    except Exception as e:
+        logger.exception("Error processing decoded measurement")
+        resp = Response()
+        resp.status_code = 400
+        resp.data = f"Error processing measurement: {e}"
+        return resp
 
 
-def process_measurement_json(data: dict):
+def process_measurement_json(data: dict) -> Response:
     """Process json measurement
 
     Args:
@@ -152,7 +169,14 @@ def process_measurement_json(data: dict):
         Flask response with status code and protobuf encoded response.
     """
 
-    return process_measurement_dict(data)
+    try:
+        return process_measurement_dict(data)
+    except Exception as e:
+        logger.exception("Error processing JSON measurement")
+        resp = Response()
+        resp.status_code = 400
+        resp.data = f"Error processing measurement: {e}"
+        return resp
 
 
 def process_measurement_dict(meas: dict):
@@ -229,6 +253,7 @@ def process_measurement_dict(meas: dict):
         obj = Sensor.add_data(
             meas_name="Photoresistivity", meas_unit="Ohms", meas_dict=meas
         )
+        obj_list.append(obj)
 
     elif meas["type"] == "pcap02":
         obj = Sensor.add_data(
@@ -275,6 +300,14 @@ def process_measurement_dict(meas: dict):
 
         obj_list.append(flow_obj)
 
+    else:
+        logger.warning("Unknown measurement type: %s", meas.get("type"))
+        resp = Response()
+        resp.content_type = "application/octet-stream"
+        resp.status_code = 501
+        resp.data = encode_response(False)
+        return resp
+
     resp = Response()
     resp.content_type = "application/octet-stream"
     if None in obj_list:
@@ -305,8 +338,8 @@ def process_measurement_dict(meas: dict):
                     )
                     if has_subscribers:
                         count = len(has_subscribers)
-                        print(f"[socketio] emitted to {room_name}: {count} subscribers")
+                        logger.debug("SocketIO emitted to %s: %d subscribers", room_name, count)
             except Exception as e:
-                print(f"[socketio] error emitting measurement: {e}")
+                logger.error("SocketIO error emitting measurement: %s", e)
 
     return resp

--- a/backend/tests/test_sensor.py
+++ b/backend/tests/test_sensor.py
@@ -105,3 +105,62 @@ def test_get_sensor_obj(init_database):
 #     data_type = db.Column(db.Text(), nullable=False)
 #     unit = db.Column(db.Text())
 #     name = db.Column(db.Text(), nullable=False)
+
+
+def test_sensor_post_invalid_binary_returns_400(init_database):
+    """Bad octet-stream payloads must not become 500 (issue #498)."""
+    response = init_database.post(
+        "/api/sensor/",
+        data=b"\x00\x00\x00",
+        content_type="application/octet-stream",
+    )
+    assert response.status_code == 400
+    assert (
+        b"Error decoding measurement" in response.data
+        or b"Error processing measurement" in response.data
+    )
+
+
+def test_sensor_post_garbage_ascii_returns_400(init_database):
+    """Lenient protobuf decode + invalid dict must be 400, not 500 (issue #498)."""
+    response = init_database.post(
+        "/api/sensor/",
+        data=b"abc",
+        content_type="application/octet-stream",
+    )
+    assert response.status_code == 400
+    assert (
+        b"Error processing measurement" in response.data
+        or b"Error decoding" in response.data
+    )
+
+
+def test_sensor_post_empty_body_returns_400(init_database):
+    """An empty binary body should be rejected gracefully (issue #498)."""
+    response = init_database.post(
+        "/api/sensor/",
+        data=b"",
+        content_type="application/octet-stream",
+    )
+    assert response.status_code == 400
+
+
+def test_sensor_post_unsupported_content_type_returns_400(init_database):
+    """Unsupported Content-Type must return 400, not 500."""
+    response = init_database.post(
+        "/api/sensor/",
+        data=b"test",
+        content_type="text/plain",
+    )
+    assert response.status_code == 400
+    assert b"Unsupported Content-Type" in response.data
+
+
+def test_sensor_json_post_unsupported_content_type_returns_400(init_database):
+    """JSON sensor endpoint must reject non-JSON Content-Type with 400."""
+    response = init_database.post(
+        "/api/sensor_json/",
+        data=b"binary-data",
+        content_type="application/octet-stream",
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary

- Fixes #498 by handling sensor measurement decode/processing failures gracefully and returning `400` instead of bubbling unhandled exceptions as `500`.
- Hardens sensor endpoints to return explicit `400` for unsupported `Content-Type` values (instead of raising `ValueError`).
- Adds regression tests for malformed binary, garbage payloads, empty payload, and unsupported content-type paths to prevent future regressions.

## What Changed

- `backend/api/resources/util.py`
  - Wrapped `decode_measurement(...)` in guarded error handling.
  - Wrapped `process_measurement_dict(...)` path to prevent unhandled exceptions from reaching Flask.
  - Added structured logging for failure paths.
  - Fixed `co2` branch to append `Photoresistivity` insertion result consistently.
  - Added explicit unsupported-measurement fallback response (`501`) for unknown measurement types.

- `backend/api/resources/sensor_data.py`
  - Replaced error-raising content-type branch with explicit `400` response.
  - Uses `request.mimetype` so `application/json; charset=utf-8` is handled correctly.

- `backend/api/resources/sensor_data_json.py`
  - Same content-type hardening as binary endpoint (`400` instead of exception path).
  - Uses `request.mimetype` for robust content-type matching.

- `backend/tests/test_sensor.py`
  - Added tests:
    - invalid binary returns `400`
    - garbage ascii payload returns `400`
    - empty body returns `400`
    - unsupported content type on `/api/sensor/` returns `400`
    - unsupported content type on `/api/sensor_json/` returns `400`

## Why

Issue #498 showed decode failures surfacing as unhandled exceptions in production logs (`/api/sensor/`), causing internal server errors.  
This PR ensures malformed client payloads are treated as client errors (`400`) with clear response messaging and test coverage.

## Validation

- Manual check:
  - `POST /api/sensor/` with invalid octet-stream payload now returns `400` with decode/processing error message.
- Automated tests:
  - `tests/test_sensor.py` passes with new regression scenarios covering the #498 failure modes.

## Risk / Impact

- Low risk: changes are localized to sensor request handling and tests.
- Behavior change is intentional and aligns with API expectations:
  - malformed requests → `400`
  - unknown measurement type → `501`
- No new third-party dependencies introduced.