### PR TITLE
Changing CI config names to reflect their job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build containers
         run: docker compose --profile ci build
 
-      - name: Lint backend
+      - name: Format backend
         run: docker compose up backend-format --abort-on-container-exit
 
   backend-lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build containers
         run: docker compose --profile ci build
 
-      - name: Lint backend
+      - name: Lint frontend
         run: docker compose up frontend-lint --abort-on-container-exit
 
   backend-test:


### PR DESCRIPTION
Frontend lint job labels the name as lint backend, likely was just copy pasted from the Backend Lint job. Update for consistency