### PR TITLE
Export CSV at the selected chart downsample

### DIFF
--- a/frontend/src/charts/ChartWrapper.jsx
+++ b/frontend/src/charts/ChartWrapper.jsx
@@ -30,7 +30,7 @@ import usePrevious from '../hooks/usePrevious';
 ChartJS.register(LineController, LineElement, PointElement, LinearScale, chartTooltip, Legend, TimeScale, zoomPlugin);
 
 //** Wrapper for chart functionality and state */
-function ChartWrapper({ id, data, options, stream, onResampleChange }) {
+function ChartWrapper({ id, data, options, stream, onResampleChange, resample = 'hour' }) {
   const [resetSelected] = useState(false);
   const [zoomSelected, setZoomSelected] = useState(false);
   const [panSelected, setPanSelected] = useState(true);
@@ -39,10 +39,14 @@ function ChartWrapper({ id, data, options, stream, onResampleChange }) {
   const handleClose = () => setOpen(false);
 
   const [resampleAnchor, setResampleAnchor] = useState(null);
-  const [selectedResample, setSelectedResample] = useState('hour');
+  const [selectedResample, setSelectedResample] = useState(resample);
   const [scaleRef, setScaleRef] = useState({});
   const [prevData, setPrevData] = useState(data);
   const prevScaleRef = usePrevious(scaleRef);
+
+  useEffect(() => {
+    setSelectedResample(resample);
+  }, [resample]);
 
   //** defines axis for charts, charts may have different axis names/
   const axes = Object.keys(options.scales);
@@ -756,4 +760,5 @@ ChartWrapper.propTypes = {
   options: PropTypes.object,
   stream: PropTypes.bool,
   onResampleChange: PropTypes.func,
+  resample: PropTypes.oneOf(['none', 'hour', 'day']),
 };

--- a/frontend/src/charts/PwrChart/PwrChart.jsx
+++ b/frontend/src/charts/PwrChart/PwrChart.jsx
@@ -6,7 +6,7 @@ import { getAxisBoundsAndStepValues } from '../alignAxis';
 import { getNonStreamTimeDomain } from '../timeDomain';
 import ChartWrapper from '../ChartWrapper';
 
-export default function PwrChart({ data, stream, startDate, endDate, onResampleChange }) {
+export default function PwrChart({ data, stream, startDate, endDate, onResampleChange, resample }) {
   const { leftYMin, leftYMax, leftYStep } = getAxisBoundsAndStepValues(data.datasets, [], 10, 5);
   const nonStreamXDomain = getNonStreamTimeDomain(stream, startDate, endDate);
 
@@ -105,6 +105,7 @@ export default function PwrChart({ data, stream, startDate, endDate, onResampleC
       options={stream ? streamChartOptions : chartOptions}
       stream={stream}
       onResampleChange={onResampleChange}
+      resample={resample}
     />
   );
 }
@@ -115,4 +116,5 @@ PwrChart.propTypes = {
   startDate: PropTypes.object,
   endDate: PropTypes.object,
   onResampleChange: PropTypes.func,
+  resample: PropTypes.oneOf(['none', 'hour', 'day']),
 };

--- a/frontend/src/charts/TempChart/TempChart.jsx
+++ b/frontend/src/charts/TempChart/TempChart.jsx
@@ -6,7 +6,7 @@ import { getAxisBoundsAndStepValues } from '../alignAxis';
 import { getNonStreamTimeDomain } from '../timeDomain';
 import ChartWrapper from '../ChartWrapper';
 
-export default function TempChart({ data, stream, startDate, endDate, onResampleChange }) {
+export default function TempChart({ data, stream, startDate, endDate, onResampleChange, resample }) {
   const { leftYMin, leftYMax, leftYStep } = getAxisBoundsAndStepValues(data.datasets, [], 10, 5);
   const nonStreamXDomain = getNonStreamTimeDomain(stream, startDate, endDate);
 
@@ -107,6 +107,7 @@ export default function TempChart({ data, stream, startDate, endDate, onResample
       options={stream ? streamChartOptions : chartOptions}
       stream={stream}
       onResampleChange={onResampleChange}
+      resample={resample}
     />
   );
 }
@@ -116,4 +117,5 @@ TempChart.propTypes = {
   startDate: PropTypes.object,
   endDate: PropTypes.object,
   onResampleChange: PropTypes.func,
+  resample: PropTypes.oneOf(['none', 'hour', 'day']),
 };

--- a/frontend/src/charts/UniversalChart.jsx
+++ b/frontend/src/charts/UniversalChart.jsx
@@ -8,7 +8,7 @@ import ChartWrapper from './ChartWrapper';
 import { chartPlugins } from './plugins';
 import { getVwcAxisBounds } from './VwcChart/vwcAxis';
 
-export default function UniversalChart({ data, stream, chartId, measurements, units, axisIds, axisPolicy, startDate, endDate, onResampleChange }) {
+export default function UniversalChart({ data, stream, chartId, measurements, units, axisIds, axisPolicy, startDate, endDate, onResampleChange, resample }) {
   // Build chart options dynamically based on measurements
   const buildChartOptions = () => {
     const nonStreamXDomain = getNonStreamTimeDomain(stream, startDate, endDate);
@@ -151,7 +151,7 @@ export default function UniversalChart({ data, stream, chartId, measurements, un
   const chartOptions = buildChartOptions();
 
   return (
-    <ChartWrapper id={chartId} data={data} options={chartOptions} stream={stream} onResampleChange={onResampleChange} />
+    <ChartWrapper id={chartId} data={data} options={chartOptions} stream={stream} onResampleChange={onResampleChange} resample={resample} />
   );
 }
 
@@ -166,4 +166,5 @@ UniversalChart.propTypes = {
   startDate: PropTypes.object,
   endDate: PropTypes.object,
   onResampleChange: PropTypes.func,
+  resample: PropTypes.oneOf(['none', 'hour', 'day']),
 };

--- a/frontend/src/charts/VChart/VChart.jsx
+++ b/frontend/src/charts/VChart/VChart.jsx
@@ -6,7 +6,7 @@ import { getAxisBoundsAndStepValues } from '../alignAxis';
 import { getNonStreamTimeDomain } from '../timeDomain';
 import ChartWrapper from '../ChartWrapper';
 
-export default function VChart({ data, stream, startDate, endDate, onResampleChange }) {
+export default function VChart({ data, stream, startDate, endDate, onResampleChange, resample }) {
   const { leftYMin, leftYMax, leftYStep, rightYMin, rightYMax, rightYStep } = getAxisBoundsAndStepValues(
     data.datasets.filter((_, i) => i % 2 == 0),
     data.datasets.filter((_, i) => i % 2 == 1),
@@ -138,6 +138,7 @@ export default function VChart({ data, stream, startDate, endDate, onResampleCha
       options={stream ? streamChartOptions : chartOptions}
       stream={stream}
       onResampleChange={onResampleChange}
+      resample={resample}
     />
   );
 }
@@ -148,4 +149,5 @@ VChart.propTypes = {
   startDate: PropTypes.object,
   endDate: PropTypes.object,
   onResampleChange: PropTypes.func,
+  resample: PropTypes.oneOf(['none', 'hour', 'day']),
 };

--- a/frontend/src/charts/VwcChart/VwcChart.jsx
+++ b/frontend/src/charts/VwcChart/VwcChart.jsx
@@ -7,7 +7,7 @@ import { getNonStreamTimeDomain } from '../timeDomain';
 import ChartWrapper from '../ChartWrapper';
 import { getVwcAxisBounds } from './vwcAxis';
 
-export default function VwcChart({ data, stream, startDate, endDate, onResampleChange }) {
+export default function VwcChart({ data, stream, startDate, endDate, onResampleChange, resample }) {
   const vwcDatasets = data.datasets.filter((_, i) => i % 2 == 0);
   const { rightYMin, rightYMax, rightYStep } = getAxisBoundsAndStepValues(
     vwcDatasets,
@@ -148,6 +148,7 @@ export default function VwcChart({ data, stream, startDate, endDate, onResampleC
       options={stream ? streamChartOptions : chartOptions}
       stream={stream}
       onResampleChange={onResampleChange}
+      resample={resample}
     />
   );
 }
@@ -158,4 +159,5 @@ VwcChart.propTypes = {
   startDate: PropTypes.object,
   endDate: PropTypes.object,
   onResampleChange: PropTypes.func,
+  resample: PropTypes.oneOf(['none', 'hour', 'day']),
 };

--- a/frontend/src/charts/__tests__/ChartWrapper.test.jsx
+++ b/frontend/src/charts/__tests__/ChartWrapper.test.jsx
@@ -813,6 +813,27 @@ describe('testing side button events', () => {
     expect(mockOnResampleChange).toHaveBeenCalledWith('day');
   });
 
+  it('marks the resample prop as the selected downsample option', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ChartWrapper
+        id='vwc-none'
+        data={data}
+        options={chartOptions}
+        stream={false}
+        resample='none'
+      />,
+    );
+
+    const downsampleBtnElement = await screen.findByLabelText(/Downsample/i);
+    await user.click(downsampleBtnElement);
+
+    const noneMenuItems = await screen.findAllByText('None');
+    const selected = noneMenuItems.some((item) => item.closest('.Mui-selected'));
+    expect(selected).toBe(true);
+  });
+
   it('should show all resample menu items', async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -65,6 +65,8 @@ function Dashboard() {
 
   const [hourlyStartDate, setHourlyStartDate] = useState(DateTime.now().minus({ days: 14 }));
   const [hourlyEndDate, setHourlyEndDate] = useState(DateTime.now());
+  // Shared downsample for charts + CSV export (#813). Default matches prior hourly caches.
+  const [historicalResample, setHistoricalResample] = useState('hour');
 
   // Mobile responsive detection
   const theme = useTheme();
@@ -184,6 +186,7 @@ function Dashboard() {
       endDate: hourlyEndDate,
       stream,
       cellSensorsById,
+      resample: historicalResample,
       enabled: historicalDatesReady && selectedCells.length > 0,
     });
 
@@ -215,6 +218,8 @@ function Dashboard() {
       historicalSensorByKey,
       historicalLoading,
       centralHistoricalActive,
+      resample: historicalResample,
+      onResampleChange: setHistoricalResample,
     }),
     [
       selectedCells,
@@ -229,6 +234,7 @@ function Dashboard() {
       historicalSensorByKey,
       historicalLoading,
       centralHistoricalActive,
+      historicalResample,
     ],
   );
 

--- a/frontend/src/pages/dashboard/catalog/cellSensorLayout.js
+++ b/frontend/src/pages/dashboard/catalog/cellSensorLayout.js
@@ -46,7 +46,12 @@ function normalizeChartKey(value) {
 }
 
 /**
- * Map a DB sensor row onto a builtin/unified panel when CHART_CONFIGS matches.
+ * Map a DB sensor row onto a UnifiedChart panel (`u:…`) when CHART_CONFIGS matches.
+ *
+ * Never maps onto builtin power/teros panels (`power-vi`, `teros`, `temp`). Those
+ * read legacy tables; generic SensorType rows (`POWER_VOLTAGE`, `TEROS12_*`) live
+ * in the sensor table. Collapsing them onto builtins drops the working `s:` chart
+ * and leaves an empty Voltage & Current panel (#815 / #816 regression).
  *
  * @param {{ name?: string, measurement?: string }} sensor
  * @returns {string | null}
@@ -62,7 +67,8 @@ export function unifiedPanelIdForSensor(sensor) {
   if (!match) return null;
 
   const panelId = CHART_TYPE_TO_PANEL_ID[match[0]];
-  return panelId && isKnownPanelId(panelId) ? panelId : null;
+  if (!panelId || !isKnownPanelId(panelId) || !panelId.startsWith('u:')) return null;
+  return panelId;
 }
 
 /**
@@ -153,7 +159,9 @@ export function panelIdsFromCellSensors(cellSensorsById, selectedCellIds) {
       );
       if (matches) {
         const panelId = CHART_TYPE_TO_PANEL_ID[chartType];
-        if (panelId && isKnownPanelId(panelId)) {
+        // Only auto-add UnifiedChart panels. Builtin power/teros come from the
+        // catalog when legacy PowerData/TEROSData rows exist.
+        if (panelId && isKnownPanelId(panelId) && panelId.startsWith('u:')) {
           panelIds.add(panelId);
         }
       }

--- a/frontend/src/pages/dashboard/catalog/cellSensorLayout.test.js
+++ b/frontend/src/pages/dashboard/catalog/cellSensorLayout.test.js
@@ -125,6 +125,21 @@ describe('chart identity / equivalent panel dedupe', () => {
     expect(dedupeEquivalentPanels(['u:co2', 's:12'], cellSensorsById)).toEqual(['u:co2']);
   });
 
+  it('does not collapse generic POWER_VOLTAGE onto builtin power-vi', () => {
+    const cellSensorsById = {
+      1: [
+        { id: 7, name: 'POWER_VOLTAGE', measurement: 'Voltage' },
+        { id: 8, name: 'BME280_TEMP', measurement: 'Temperature' },
+      ],
+    };
+
+    expect(chartIdentityForPanel('s:7', cellSensorsById)).toBe('sensor:power_voltage:voltage');
+    expect(panelIdsFromCellSensors(cellSensorsById, [1]).has('power-vi')).toBe(false);
+    expect(
+      dedupeEquivalentPanels(['power-vi', 's:7', 's:8'], cellSensorsById),
+    ).toEqual(['power-vi', 's:7', 's:8']);
+  });
+
   it('treats a catalog row for another cell as the same chart', () => {
     expect(
       chartIdentityForCatalogEntry({

--- a/frontend/src/pages/dashboard/catalog/historicalDataLoader.test.js
+++ b/frontend/src/pages/dashboard/catalog/historicalDataLoader.test.js
@@ -168,4 +168,30 @@ describe('historicalDataLoader', () => {
       sensorDataCacheKey(1, 'rocketlogger', 'soil_moisture'),
     );
   });
+
+  it('forwards none/day resample to sensor fetches used by CSV export', async () => {
+    getSensorData.mockResolvedValue({ timestamp: [], data: [1] });
+    const start = DateTime.fromISO('2026-06-01T00:00:00');
+    const end = DateTime.fromISO('2026-06-02T00:00:00');
+
+    await fetchDashboardSensorData({
+      cells: [{ id: 1, name: 'Cell A' }],
+      panelOrder: ['s:37'],
+      startDate: start,
+      endDate: end,
+      resample: 'none',
+      cellSensorsById: {
+        1: [{ id: 37, name: 'rocketlogger', measurement: 'soil_moisture' }],
+      },
+    });
+
+    expect(getSensorData).toHaveBeenCalledWith(
+      'rocketlogger',
+      1,
+      'soil_moisture',
+      start.toHTTP(),
+      end.toHTTP(),
+      'none',
+    );
+  });
 });

--- a/frontend/src/pages/dashboard/components/DashboardPanelGrid.jsx
+++ b/frontend/src/pages/dashboard/components/DashboardPanelGrid.jsx
@@ -43,6 +43,8 @@ function DashboardPanelContent({ panelId, chartProps }) {
         historicalSensorByKey={chartProps.historicalSensorByKey}
         historicalLoading={chartProps.historicalLoading}
         centralHistoricalActive={chartProps.centralHistoricalActive?.equations}
+        resample={chartProps.resample}
+        onResampleChange={chartProps.onResampleChange}
       />
     );
   }
@@ -53,6 +55,8 @@ function DashboardPanelContent({ panelId, chartProps }) {
     endDate: chartProps.endDate,
     stream: chartProps.stream,
     liveData: chartProps.liveData,
+    resample: chartProps.resample,
+    onResampleChange: chartProps.onResampleChange,
   };
 
   if (isSensorPanelEntry(panelId)) {
@@ -78,6 +82,8 @@ function DashboardPanelContent({ panelId, chartProps }) {
         historicalSensorByKey={chartProps.historicalSensorByKey}
         centralHistoricalActive={chartProps.centralHistoricalActive?.sensors}
         historicalLoading={chartProps.historicalLoading}
+        resample={chartProps.resample}
+        onResampleChange={chartProps.onResampleChange}
       />
     );
   }
@@ -97,6 +103,8 @@ function DashboardPanelContent({ panelId, chartProps }) {
         historicalSensorByKey={chartProps.historicalSensorByKey}
         centralHistoricalActive={chartProps.centralHistoricalActive?.sensors}
         historicalLoading={chartProps.historicalLoading}
+        resample={chartProps.resample}
+        onResampleChange={chartProps.onResampleChange}
       />
     );
   }
@@ -281,6 +289,8 @@ DashboardPanelGrid.propTypes = {
     historicalTerosByCell: PropTypes.object,
     historicalSensorByKey: PropTypes.object,
     historicalLoading: PropTypes.bool,
+    resample: PropTypes.oneOf(['none', 'hour', 'day']),
+    onResampleChange: PropTypes.func,
     centralHistoricalActive: PropTypes.shape({
       power: PropTypes.bool,
       teros: PropTypes.bool,

--- a/frontend/src/pages/dashboard/components/DerivedEquationChart.jsx
+++ b/frontend/src/pages/dashboard/components/DerivedEquationChart.jsx
@@ -15,8 +15,11 @@ function DerivedEquationChart({
   historicalSensorByKey,
   historicalLoading = false,
   centralHistoricalActive = false,
+  resample: resampleProp,
+  onResampleChange,
 }) {
-  const [resample, setResample] = useState('hour');
+  const [localResample, setLocalResample] = useState('hour');
+  const resample = resampleProp ?? localResample;
   const [chartData, setChartData] = useState({ datasets: [] });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -25,10 +28,11 @@ function DerivedEquationChart({
   useEffect(() => {
     if (stream) return undefined;
 
-    const useCentralCache = centralHistoricalActive && resample === 'hour';
+    const useCentralCache = Boolean(centralHistoricalActive);
     if (useCentralCache && historicalLoading) {
       setIsLoading(true);
       setError(null);
+      setChartData({ datasets: [] });
       return undefined;
     }
 
@@ -130,7 +134,8 @@ function DerivedEquationChart({
       axisIds={['y']}
       startDate={startDate}
       endDate={endDate}
-      onResampleChange={setResample}
+      onResampleChange={onResampleChange || setLocalResample}
+      resample={resample}
     />
   );
 }
@@ -145,6 +150,8 @@ DerivedEquationChart.propTypes = {
   historicalSensorByKey: PropTypes.object,
   historicalLoading: PropTypes.bool,
   centralHistoricalActive: PropTypes.bool,
+  resample: PropTypes.oneOf(['none', 'hour', 'day']),
+  onResampleChange: PropTypes.func,
 };
 
 export default DerivedEquationChart;

--- a/frontend/src/pages/dashboard/components/PowerCharts.jsx
+++ b/frontend/src/pages/dashboard/components/PowerCharts.jsx
@@ -18,8 +18,11 @@ function PowerCharts({
   historicalPowerByCell,
   centralHistoricalActive = false,
   historicalLoading = false,
+  resample: resampleProp,
+  onResampleChange,
 }) {
-  const [resample, setResample] = useState('hour');
+  const [localResample, setLocalResample] = useState('hour');
+  const resample = resampleProp ?? localResample;
   const chartSettings = {
     labels: [],
     datasets: [],
@@ -139,16 +142,36 @@ function PowerCharts({
     setHasData(hasAnyData);
   }
 
+  //** clearing all chart settings */
+  function clearCharts() {
+    const newVChartData = {
+      ...vChartData,
+      labels: [],
+      datasets: [],
+    };
+    const newPwrChartData = {
+      ...pwrChartData,
+      labels: [],
+      datasets: [],
+    };
+    setVChartData(Object.assign({}, newVChartData));
+    setPwrChartData(Object.assign({}, newPwrChartData));
+    setHasData(false);
+  }
+
   function updateCharts() {
     const fetchGeneration = ++fetchGenerationRef.current;
     const loadCells = cells;
 
-    if (centralHistoricalActive && resample === 'hour') {
+    if (centralHistoricalActive) {
       if (historicalLoading) return;
       if (fetchGeneration !== fetchGenerationRef.current) return;
       const cellChartData = historicalPowerByCell ?? {};
       const hasCentralData = cells.some(({ id }) => resolveCellEntry(cellChartData, id));
-      if (!hasCentralData) return;
+      if (!hasCentralData) {
+        clearCharts();
+        return;
+      }
       applyCellChartData(cellChartData, loadCells);
       return;
     }
@@ -165,24 +188,6 @@ function PowerCharts({
         console.error('Error updating power charts:', error);
         setHasData(false);
       });
-  }
-
-
-  //** clearing all chart settings */
-  function clearCharts() {
-    const newVChartData = {
-      ...vChartData,
-      labels: [],
-      datasets: [],
-    };
-    const newPwrChartData = {
-      ...pwrChartData,
-      labels: [],
-      datasets: [],
-    };
-    setVChartData(Object.assign({}, newVChartData));
-    setPwrChartData(Object.assign({}, newPwrChartData));
-    setHasData(false);
   }
 
   // Removed unused clearChartDatasets function
@@ -300,7 +305,8 @@ function PowerCharts({
 
 
   const handleResampleChange = (newResample) => {
-    setResample(newResample);
+    if (onResampleChange) onResampleChange(newResample);
+    else setLocalResample(newResample);
   };
 
   // Notify parent component when data status changes
@@ -310,10 +316,11 @@ function PowerCharts({
     }
   }, [hasData, onDataStatusChange]);
 
+  if (centralHistoricalActive && historicalLoading && !stream) {
+    return <ChartPanelPlaceholder loading />;
+  }
+
   if (!hasData) {
-    if (centralHistoricalActive && historicalLoading && !stream) {
-      return <ChartPanelPlaceholder loading />;
-    }
     if (cells?.length) {
       return <ChartPanelPlaceholder />;
     }
@@ -329,6 +336,7 @@ function PowerCharts({
       stream={stream}
       {...(!stream && { startDate, endDate })}
       onResampleChange={handleResampleChange}
+      resample={resample}
     />
   );
 
@@ -338,6 +346,7 @@ function PowerCharts({
       stream={stream}
       {...(!stream && { startDate, endDate })}
       onResampleChange={handleResampleChange}
+      resample={resample}
     />
   );
 
@@ -381,6 +390,8 @@ PowerCharts.propTypes = {
   historicalPowerByCell: PropTypes.object,
   centralHistoricalActive: PropTypes.bool,
   historicalLoading: PropTypes.bool,
+  resample: PropTypes.oneOf(['none', 'hour', 'day']),
+  onResampleChange: PropTypes.func,
 };
 
 export default PowerCharts;

--- a/frontend/src/pages/dashboard/components/TerosCharts.jsx
+++ b/frontend/src/pages/dashboard/components/TerosCharts.jsx
@@ -20,8 +20,11 @@ function TerosCharts({
   historicalTerosByCell,
   centralHistoricalActive = false,
   historicalLoading = false,
+  resample: resampleProp,
+  onResampleChange,
 }) {
-  const [resample, setResample] = useState('hour');
+  const [localResample, setLocalResample] = useState('hour');
+  const resample = resampleProp ?? localResample;
   const chartSettings = {
     datasets: [],
   };
@@ -137,16 +140,36 @@ function TerosCharts({
     setHasData(hasAnyData);
   }
 
+  //** clearing all chart settings */
+  function clearCharts() {
+    const newVwcChartData = {
+      ...vwcChartData,
+      labels: [],
+      datasets: [],
+    };
+    const newTempChartData = {
+      ...tempChartData,
+      labels: [],
+      datasets: [],
+    };
+    setVwcChartData(Object.assign({}, newVwcChartData));
+    setTempChartData(Object.assign({}, newTempChartData));
+    setHasData(false);
+  }
+
   function updateCharts() {
     const fetchGeneration = ++fetchGenerationRef.current;
     const loadCells = cells;
 
-    if (centralHistoricalActive && resample === 'hour') {
+    if (centralHistoricalActive) {
       if (historicalLoading) return;
       if (fetchGeneration !== fetchGenerationRef.current) return;
       const cellChartData = historicalTerosByCell ?? {};
       const hasCentralData = cells.some(({ id }) => resolveCellEntry(cellChartData, id));
-      if (!hasCentralData) return;
+      if (!hasCentralData) {
+        clearCharts();
+        return;
+      }
       applyCellChartData(cellChartData, loadCells);
       return;
     }
@@ -163,23 +186,6 @@ function TerosCharts({
         console.error('Error updating TEROS charts:', error);
         setHasData(false);
       });
-  }
-
-  //** clearing all chart settings */
-  function clearCharts() {
-    const newVwcChartData = {
-      ...vwcChartData,
-      labels: [],
-      datasets: [],
-    };
-    const newTempChartData = {
-      ...tempChartData,
-      labels: [],
-      datasets: [],
-    };
-    setVwcChartData(Object.assign({}, newVwcChartData));
-    setTempChartData(Object.assign({}, newTempChartData));
-    setHasData(false);
   }
 
   // Removed unused clearChartDatasets function
@@ -293,7 +299,8 @@ function TerosCharts({
   }, [cells, stream, resample, startDate, endDate, historicalTerosByCell, centralHistoricalActive, historicalLoading]);
 
   const handleResampleChange = (newResample) => {
-    setResample(newResample);
+    if (onResampleChange) onResampleChange(newResample);
+    else setLocalResample(newResample);
   };
 
   // Notify parent component when data status changes
@@ -303,10 +310,11 @@ function TerosCharts({
     }
   }, [hasData, onDataStatusChange]);
 
+  if (centralHistoricalActive && historicalLoading && !stream) {
+    return <ChartPanelPlaceholder loading />;
+  }
+
   if (!hasData) {
-    if (centralHistoricalActive && historicalLoading && !stream) {
-      return <ChartPanelPlaceholder loading />;
-    }
     if (cells?.length) {
       return <ChartPanelPlaceholder />;
     }
@@ -322,6 +330,7 @@ function TerosCharts({
       stream={stream}
       {...(!stream && { startDate, endDate })}
       onResampleChange={handleResampleChange}
+      resample={resample}
     />
   );
 
@@ -331,6 +340,7 @@ function TerosCharts({
       stream={stream}
       {...(!stream && { startDate, endDate })}
       onResampleChange={handleResampleChange}
+      resample={resample}
     />
   );
 
@@ -374,6 +384,8 @@ TerosCharts.propTypes = {
   historicalTerosByCell: PropTypes.object,
   centralHistoricalActive: PropTypes.bool,
   historicalLoading: PropTypes.bool,
+  resample: PropTypes.oneOf(['none', 'hour', 'day']),
+  onResampleChange: PropTypes.func,
 };
 
 export default TerosCharts;

--- a/frontend/src/pages/dashboard/components/UnifiedChart.jsx
+++ b/frontend/src/pages/dashboard/components/UnifiedChart.jsx
@@ -39,8 +39,11 @@ function UnifiedChart({
   historicalSensorByKey,
   centralHistoricalActive = false,
   historicalLoading = false,
+  resample: resampleProp,
+  onResampleChange,
 }) {
-  const [resample, setResample] = useState('hour');
+  const [localResample, setLocalResample] = useState('hour');
+  const resample = resampleProp ?? localResample;
   const chartSettings = {
     label: [],
     datasets: [],
@@ -84,7 +87,7 @@ function UnifiedChart({
   ];
 
   async function getCellChartData() {
-    if (centralHistoricalActive && resample === 'hour') {
+    if (centralHistoricalActive) {
       if (historicalLoading || !historicalSensorByKey || Object.keys(historicalSensorByKey).length === 0) {
         return {};
       }
@@ -160,7 +163,7 @@ function UnifiedChart({
   }
 
   function updateCharts() {
-    if (centralHistoricalActive && resample === 'hour' && historicalLoading) {
+    if (centralHistoricalActive && historicalLoading) {
       setIsLoading(true);
       return;
     }
@@ -381,6 +384,12 @@ function UnifiedChart({
   }, [stream, liveData, cells, processedData, type, sensor_name, measurements, units, axisIds]);
 
   useEffect(() => {
+    if (!stream && centralHistoricalActive && historicalLoading) {
+      setIsLoading(true);
+    }
+  }, [stream, centralHistoricalActive, historicalLoading]);
+
+  useEffect(() => {
     if (debounceTimer.current) {
       clearTimeout(debounceTimer.current);
     }
@@ -402,7 +411,8 @@ function UnifiedChart({
   }, [cells, stream, resample, startDate, endDate, cellSensorsById, historicalSensorByKey, centralHistoricalActive, historicalLoading]);
 
   const handleResampleChange = (newResample) => {
-    setResample(newResample);
+    if (onResampleChange) onResampleChange(newResample);
+    else setLocalResample(newResample);
   };
 
   const hasRenderableData = sensorChartData.datasets.some((ds) => Array.isArray(ds.data) && ds.data.length > 0);
@@ -446,6 +456,7 @@ function UnifiedChart({
         axisPolicy={axisPolicy}
         {...(!stream && { startDate, endDate })}
         onResampleChange={handleResampleChange}
+        resample={resample}
       />
     </Box>
   );
@@ -472,6 +483,8 @@ UnifiedChart.propTypes = {
   historicalSensorByKey: PropTypes.object,
   centralHistoricalActive: PropTypes.bool,
   historicalLoading: PropTypes.bool,
+  resample: PropTypes.oneOf(['none', 'hour', 'day']),
+  onResampleChange: PropTypes.func,
 };
 
 export default UnifiedChart;

--- a/frontend/src/pages/dashboard/equation/equationData.js
+++ b/frontend/src/pages/dashboard/equation/equationData.js
@@ -118,11 +118,12 @@ async function fetchRefMap(ref, startDate, endDate, resample, cache = null, useC
   const cellId = Number(match[1]);
   const streamKey = match[2];
 
-  if (useCache && cache) {
+  if (useCache) {
     const cachedSeries = streamSeriesFromHistoricalCache(cellId, streamKey, cache);
     if (cachedSeries) {
       return seriesToRefMap(cachedSeries);
     }
+    return new Map();
   }
 
   const { timestamps, values } = await fetchStreamSeries(cellId, streamKey, startDate, endDate, resample);
@@ -139,7 +140,7 @@ async function fetchRefMap(ref, startDate, endDate, resample, cache = null, useC
  */
 export async function buildDerivedSeries(expression, startDate, endDate, resample = 'hour', options = {}) {
   const { useCentralCache = false, historicalCache = null } = options;
-  const useCache = useCentralCache && resample === 'hour' && historicalCache != null;
+  const useCache = Boolean(useCentralCache);
 
   const refs = extractCellStreamRefs(expression);
   if (refs.length === 0) return null;

--- a/frontend/src/pages/dashboard/equation/equationData.test.js
+++ b/frontend/src/pages/dashboard/equation/equationData.test.js
@@ -97,6 +97,42 @@ describe('equationData', () => {
     expect(result?.timestamps).toEqual([ts]);
   });
 
+  it('buildDerivedSeries uses cache for none resample when central cache is active', async () => {
+    const start = DateTime.fromISO('2026-06-01T00:00:00');
+    const end = DateTime.fromISO('2026-06-02T00:00:00');
+
+    const result = await buildDerivedSeries('1:vwc / 1:temp', start, end, 'none', {
+      useCentralCache: true,
+      historicalCache: {
+        historicalTerosByCell: {
+          1: {
+            terosData: {
+              timestamp: ['Thu, 18 Jun 2026 00:00:00 GMT'],
+              vwc: [20],
+              temp: [2],
+            },
+          },
+        },
+      },
+    });
+
+    expect(getTerosData).not.toHaveBeenCalled();
+    expect(result?.values).toEqual([10]);
+  });
+
+  it('buildDerivedSeries does not network-fetch when central cache is active but empty', async () => {
+    const start = DateTime.fromISO('2026-06-01T00:00:00');
+    const end = DateTime.fromISO('2026-06-02T00:00:00');
+
+    const result = await buildDerivedSeries('1:vwc / 1:temp', start, end, 'none', {
+      useCentralCache: true,
+      historicalCache: {},
+    });
+
+    expect(getTerosData).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
   it('buildDerivedSeries fetches when cache is disabled', async () => {
     const start = DateTime.fromISO('2026-06-01T00:00:00');
     const end = DateTime.fromISO('2026-06-02T00:00:00');

--- a/frontend/src/pages/dashboard/hooks/useDashboardHistoricalData.js
+++ b/frontend/src/pages/dashboard/hooks/useDashboardHistoricalData.js
@@ -7,6 +7,55 @@ import {
 const EMPTY = {};
 
 /**
+ * @param {string} powerRequestKey
+ * @param {string} sensorRequestKey
+ * @param {string|null} powerCacheKey
+ * @param {string|null} sensorCacheKey
+ * @param {boolean} powerLoading
+ * @param {boolean} sensorLoading
+ * @returns {boolean}
+ */
+export function isHistoricalCacheReady(
+  powerRequestKey,
+  sensorRequestKey,
+  powerCacheKey,
+  sensorCacheKey,
+  powerLoading,
+  sensorLoading,
+) {
+  return (
+    !powerLoading &&
+    !sensorLoading &&
+    powerCacheKey === powerRequestKey &&
+    sensorCacheKey === sensorRequestKey
+  );
+}
+
+/**
+ * Never hand callers a cache that belongs to a different resample/range/selection.
+ * CSV and charts must see empty objects until both halves match the request.
+ *
+ * @param {boolean} ready
+ * @param {Record<string, unknown>} power
+ * @param {Record<string, unknown>} teros
+ * @param {Record<string, unknown>} sensors
+ */
+export function selectPublishedHistoricalCaches(ready, power, teros, sensors) {
+  if (!ready) {
+    return {
+      historicalPowerByCell: EMPTY,
+      historicalTerosByCell: EMPTY,
+      historicalSensorByKey: EMPTY,
+    };
+  }
+  return {
+    historicalPowerByCell: power,
+    historicalTerosByCell: teros,
+    historicalSensorByKey: sensors,
+  };
+}
+
+/**
  * Central historical loader for dashboard panels (catalog-gated, deduped, stale-safe).
  */
 export function useDashboardHistoricalData({
@@ -24,6 +73,8 @@ export function useDashboardHistoricalData({
   const [historicalSensorByKey, setHistoricalSensorByKey] = useState(EMPTY);
   const [powerTerosLoading, setPowerTerosLoading] = useState(false);
   const [sensorLoading, setSensorLoading] = useState(false);
+  const [powerCacheKey, setPowerCacheKey] = useState(null);
+  const [sensorCacheKey, setSensorCacheKey] = useState(null);
 
   const cellIdsKey = useMemo(() => cells.map((cell) => cell.id).join(','), [cells]);
   const panelOrderKey = useMemo(() => panelOrder.join(','), [panelOrder]);
@@ -32,13 +83,22 @@ export function useDashboardHistoricalData({
     [startDate, endDate],
   );
   const sensorInputsKey = useMemo(() => JSON.stringify(cellSensorsById ?? {}), [cellSensorsById]);
+  const powerRequestKey = `${resample}|${rangeKey}|${cellIdsKey}|${panelOrderKey}`;
+  const sensorRequestKey = `${powerRequestKey}|${sensorInputsKey}`;
   const cellSnapshot = useMemo(
     () => cells.map(({ id, name }) => ({ id, name })),
     [cells],
   );
   const panelOrderSnapshot = useMemo(() => [...panelOrder], [panelOrder]);
   const sensorInputs = useMemo(() => cellSensorsById ?? {}, [cellSensorsById]);
-  const historicalLoading = powerTerosLoading || sensorLoading;
+  const historicalLoading = !isHistoricalCacheReady(
+    powerRequestKey,
+    sensorRequestKey,
+    powerCacheKey,
+    sensorCacheKey,
+    powerTerosLoading,
+    sensorLoading,
+  );
 
   useEffect(() => {
     if (!enabled || stream) {
@@ -47,6 +107,8 @@ export function useDashboardHistoricalData({
       setHistoricalPowerByCell(EMPTY);
       setHistoricalTerosByCell(EMPTY);
       setHistoricalSensorByKey(EMPTY);
+      setPowerCacheKey(null);
+      setSensorCacheKey(null);
       return undefined;
     }
 
@@ -56,6 +118,7 @@ export function useDashboardHistoricalData({
       setHistoricalPowerByCell(EMPTY);
       setHistoricalTerosByCell(EMPTY);
       setHistoricalSensorByKey(EMPTY);
+      setPowerCacheKey(powerRequestKey);
       return undefined;
     }
 
@@ -82,18 +145,24 @@ export function useDashboardHistoricalData({
       })
       .finally(() => {
         if (cancelled) return;
+        setPowerCacheKey(powerRequestKey);
         setPowerTerosLoading(false);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [enabled, stream, cellIdsKey, panelOrderKey, rangeKey, resample, cellSnapshot, panelOrderSnapshot, startDate, endDate]);
+  }, [enabled, stream, cellIdsKey, panelOrderKey, rangeKey, resample, powerRequestKey, cellSnapshot, panelOrderSnapshot, startDate, endDate]);
 
   useEffect(() => {
-    if (!enabled || stream || !cellIdsKey || !panelOrderKey) {
+    if (!enabled || stream) {
+      return undefined;
+    }
+
+    if (!cellIdsKey || !panelOrderKey) {
       setSensorLoading(false);
       setHistoricalSensorByKey(EMPTY);
+      setSensorCacheKey(sensorRequestKey);
       return undefined;
     }
 
@@ -119,6 +188,7 @@ export function useDashboardHistoricalData({
       })
       .finally(() => {
         if (cancelled) return;
+        setSensorCacheKey(sensorRequestKey);
         setSensorLoading(false);
       });
 
@@ -132,6 +202,7 @@ export function useDashboardHistoricalData({
     panelOrderKey,
     rangeKey,
     resample,
+    sensorRequestKey,
     sensorInputsKey,
     sensorInputs,
     cellSnapshot,
@@ -140,5 +211,17 @@ export function useDashboardHistoricalData({
     endDate,
   ]);
 
-  return { historicalPowerByCell, historicalTerosByCell, historicalSensorByKey, historicalLoading };
+  const published = selectPublishedHistoricalCaches(
+    !historicalLoading,
+    historicalPowerByCell,
+    historicalTerosByCell,
+    historicalSensorByKey,
+  );
+
+  return {
+    historicalPowerByCell: published.historicalPowerByCell,
+    historicalTerosByCell: published.historicalTerosByCell,
+    historicalSensorByKey: published.historicalSensorByKey,
+    historicalLoading,
+  };
 }

--- a/frontend/src/pages/dashboard/hooks/useDashboardHistoricalData.test.js
+++ b/frontend/src/pages/dashboard/hooks/useDashboardHistoricalData.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isHistoricalCacheReady,
+  selectPublishedHistoricalCaches,
+} from './useDashboardHistoricalData';
+
+describe('isHistoricalCacheReady', () => {
+  it('is false on the first render after resample changes (stale hourly cache)', () => {
+    expect(
+      isHistoricalCacheReady(
+        'none|range|1|power-vi',
+        'none|range|1|power-vi|{}',
+        'hour|range|1|power-vi',
+        'hour|range|1|power-vi|{}',
+        false,
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it('is false while either half is still fetching', () => {
+    expect(isHistoricalCacheReady('k', 'k|s', 'k', 'k|s', true, false)).toBe(false);
+    expect(isHistoricalCacheReady('k', 'k|s', 'k', 'k|s', false, true)).toBe(false);
+  });
+
+  it('is false when only the sensor catalog key is stale', () => {
+    expect(isHistoricalCacheReady('k', 'k|{new}', 'k', 'k|{old}', false, false)).toBe(false);
+  });
+
+  it('is true only when both halves match the requested keys and are idle', () => {
+    expect(isHistoricalCacheReady('k', 'k|s', 'k', 'k|s', false, false)).toBe(true);
+  });
+});
+
+describe('selectPublishedHistoricalCaches', () => {
+  it('hides leftover hourly series while a none/day refetch is in flight', () => {
+    const published = selectPublishedHistoricalCaches(
+      false,
+      { 1: { powerData: { v: [1] } } },
+      { 1: { terosData: { vwc: [2] } } },
+      { '1:co2:co2': { data: [3] } },
+    );
+
+    expect(published).toEqual({
+      historicalPowerByCell: {},
+      historicalTerosByCell: {},
+      historicalSensorByKey: {},
+    });
+  });
+
+  it('publishes caches only when they match the requested downsample', () => {
+    const power = { 1: { powerData: { v: [1] } } };
+    const teros = { 1: { terosData: { vwc: [2] } } };
+    const sensors = { '1:co2:co2': { data: [3] } };
+
+    expect(selectPublishedHistoricalCaches(true, power, teros, sensors)).toEqual({
+      historicalPowerByCell: power,
+      historicalTerosByCell: teros,
+      historicalSensorByKey: sensors,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #813.

CSV export was always built from the dashboard’s **hourly** historical cache, even when a chart downsample was set to **None** or **Daily**.

This change uses **one shared downsample** (`none` / `hour` / `day`) for charts and the central historical cache. Changing downsample on any chart refetches that cache, so **Export to CSV** writes the same resolution the charts are using.

While a refetch is in flight, the hook does **not** expose leftover hourly series (callers see empty caches and `historicalLoading`). Export stays disabled, and charts show a loading placeholder instead of the previous line.

## Test plan

- [ ] Load the dashboard with a cell and date range, leave downsample on **Hourly**, export CSV, and confirm hourly timestamps
- [ ] Switch any chart to **None**, wait until charts finish loading, export again, and confirm raw (non-hourly) timestamps
- [ ] Switch to **Daily**, wait for load, export, and confirm daily timestamps
- [ ] Change downsample and confirm **Export to CSV** shows `DOWNLOADING...` / is disabled until the new data is ready
- [ ] Confirm changing downsample on one chart updates the other charts to the same setting
- [ ] Toggle **Live** and back; historical charts and export still use the last selected downsample