### PR TITLE
Dedupe same-type charts when adding across cells

### DIFF
--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -29,7 +29,9 @@ import {
 } from './catalog/dashboardCatalog';
 import {
   availablePanelIdsForCells,
+  chartIdentityForPanel,
   defaultPanelOrderFromFetched,
+  dedupeEquivalentPanels,
   fetchCatalogPanelIdsForCells,
   fetchCellSensorsForCells,
   panelsMissingForCells,
@@ -232,10 +234,21 @@ function Dashboard() {
     ],
   );
 
-  const handleAddPanel = useCallback((panelId) => {
-    if (!isKnownPanelId(panelId)) return;
-    setPanelOrder((prev) => (prev.includes(panelId) ? prev : [...prev, panelId]));
-  }, []);
+  const handleAddPanel = useCallback(
+    (panelId) => {
+      if (!isKnownPanelId(panelId)) return;
+      setPanelOrder((prev) => {
+        if (prev.includes(panelId)) return prev;
+        const identity = chartIdentityForPanel(panelId, cellSensorsById);
+        const alreadyShown = prev.some(
+          (existing) => chartIdentityForPanel(existing, cellSensorsById) === identity,
+        );
+        if (alreadyShown) return prev;
+        return [...prev, panelId];
+      });
+    },
+    [cellSensorsById],
+  );
 
   const handleEditEquation = useCallback((currentExpression) => {
     setEquationModalMode('edit');
@@ -407,6 +420,8 @@ function Dashboard() {
           setPanelOrder(defaultOrder.length > 0 ? defaultOrder : DEFAULT_DASHBOARD_PANEL_ORDER);
           setLayoutMismatchOpen(false);
           setLayoutMismatchPanels([]);
+        } else {
+          setPanelOrder((prev) => dedupeEquivalentPanels(prev, sensors));
         }
       },
     );
@@ -855,6 +870,7 @@ useEffect(() => {
                   onClose={() => setAddChartOpen(false)}
                   selectedCells={selectedCells}
                   panelOrder={panelOrder}
+                  cellSensorsById={cellSensorsById}
                   onAddPanel={handleAddPanel}
                 />
                 <AddEquationModal

--- a/frontend/src/pages/dashboard/catalog/cellSensorLayout.js
+++ b/frontend/src/pages/dashboard/catalog/cellSensorLayout.js
@@ -9,6 +9,7 @@ import {
   isKnownPanelId,
   isSensorPanelEntry,
 } from './dashboardCatalog';
+import { findSensorByPanelId } from './historicalDataLoader';
 
 /** Map UnifiedChart config keys to dashboard panel IDs. */
 const CHART_TYPE_TO_PANEL_ID = {
@@ -37,6 +38,93 @@ function withoutRedundantPanels(panelIds) {
   if (next.has('u:presHum')) {
     next.delete('u:bme280Pressure');
   }
+  return next;
+}
+
+function normalizeChartKey(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+/**
+ * Map a DB sensor row onto a builtin/unified panel when CHART_CONFIGS matches.
+ *
+ * @param {{ name?: string, measurement?: string }} sensor
+ * @returns {string | null}
+ */
+export function unifiedPanelIdForSensor(sensor) {
+  if (!sensor?.name) return null;
+
+  const match = Object.entries(CHART_CONFIGS).find(
+    ([, config]) =>
+      sensor.name === config.sensor_name &&
+      measurementMatches(sensor.measurement, config.measurements),
+  );
+  if (!match) return null;
+
+  const panelId = CHART_TYPE_TO_PANEL_ID[match[0]];
+  return panelId && isKnownPanelId(panelId) ? panelId : null;
+}
+
+/**
+ * Stable identity so Soil Tension on cell A (`s:2029`) and cell B (`s:2030`)
+ * occupy one chart. Unified types reuse their panel id; unmatched sensors
+ * group by name + measurement.
+ *
+ * @param {string} panelId
+ * @param {Record<string, unknown[]>} [cellSensorsById]
+ * @returns {string}
+ */
+export function chartIdentityForPanel(panelId, cellSensorsById) {
+  if (!panelId) return '';
+  if (isDerivedLayoutEntry(panelId)) return `eq:${panelId}`;
+  if (!isSensorPanelEntry(panelId)) return panelId;
+
+  const sensor = findSensorByPanelId(cellSensorsById, panelId);
+  if (!sensor?.name) return panelId;
+
+  const unified = unifiedPanelIdForSensor(sensor);
+  if (unified) return unified;
+  return `sensor:${normalizeChartKey(sensor.name)}:${normalizeChartKey(sensor.measurement)}`;
+}
+
+/**
+ * @param {{ panelId: string, kind?: string, sensorName?: string, measurement?: string }} entry
+ * @returns {string}
+ */
+export function chartIdentityForCatalogEntry(entry) {
+  if (!entry?.panelId) return '';
+  if (entry.kind === 'sensor' || isSensorPanelEntry(entry.panelId)) {
+    if (entry.sensorName) {
+      const unified = unifiedPanelIdForSensor({
+        name: entry.sensorName,
+        measurement: entry.measurement,
+      });
+      if (unified) return unified;
+      return `sensor:${normalizeChartKey(entry.sensorName)}:${normalizeChartKey(entry.measurement)}`;
+    }
+  }
+  return entry.panelId;
+}
+
+/**
+ * Keep the first panel of each chart identity. Later `s:` ids for the same
+ * measurement are dropped — UnifiedChart already overlays all selected cells.
+ *
+ * @param {string[]} panelOrder
+ * @param {Record<string, unknown[]>} [cellSensorsById]
+ * @returns {string[]}
+ */
+export function dedupeEquivalentPanels(panelOrder, cellSensorsById) {
+  if (!Array.isArray(panelOrder) || panelOrder.length === 0) return [];
+
+  const seen = new Set();
+  const next = [];
+  panelOrder.forEach((panelId) => {
+    const identity = chartIdentityForPanel(panelId, cellSensorsById);
+    if (seen.has(identity)) return;
+    seen.add(identity);
+    next.push(panelId);
+  });
   return next;
 }
 
@@ -155,7 +243,7 @@ export async function fetchCatalogPanelIdsForCells(cellIds) {
 export function defaultPanelOrderFromFetched(cellSensorsById, cellIds, catalogPanelIds = []) {
   const fromSensors = panelIdsFromCellSensors(cellSensorsById, cellIds);
   const panelSet = withoutRedundantPanels([...catalogPanelIds, ...fromSensors]);
-  return sortPanelIds(panelSet);
+  return dedupeEquivalentPanels(sortPanelIds(panelSet), cellSensorsById);
 }
 
 export async function buildDefaultPanelOrder(cellIds) {

--- a/frontend/src/pages/dashboard/catalog/cellSensorLayout.test.js
+++ b/frontend/src/pages/dashboard/catalog/cellSensorLayout.test.js
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildDefaultPanelOrder,
+  chartIdentityForCatalogEntry,
+  chartIdentityForPanel,
+  dedupeEquivalentPanels,
   panelIdsFromCellSensors,
   sortPanelIds,
   panelsMissingForCells,
@@ -85,7 +88,51 @@ describe('buildDefaultPanelOrder', () => {
     expect(panelOrder[0]).toBe('power-vi');
     expect(panelOrder).toContain('teros');
     expect(panelOrder).toContain('u:co2');
-    expect(panelOrder).toContain('s:5');
+    expect(panelOrder).not.toContain('s:5');
     expect(cellSensorsById['1']).toHaveLength(1);
+  });
+});
+
+describe('chart identity / equivalent panel dedupe', () => {
+  const soilTension = (id, cellId) => ({
+    id,
+    name: 'watermark',
+    measurement: 'soil_tension',
+    cellId,
+  });
+
+  it('groups per-cell s: panels of the same sensor type', () => {
+    const cellSensorsById = {
+      407: [soilTension(2029, 407)],
+      408: [soilTension(2030, 408)],
+      2578: [soilTension(2028, 2578)],
+    };
+
+    expect(chartIdentityForPanel('s:2029', cellSensorsById)).toBe('sensor:watermark:soil_tension');
+    expect(chartIdentityForPanel('s:2030', cellSensorsById)).toBe(
+      chartIdentityForPanel('s:2029', cellSensorsById),
+    );
+    expect(
+      dedupeEquivalentPanels(['s:2029', 's:2030', 's:2028', 's:118'], cellSensorsById),
+    ).toEqual(['s:2029', 's:118']);
+  });
+
+  it('collapses a db sensor panel onto its unified catalog counterpart', () => {
+    const cellSensorsById = {
+      1: [{ id: 12, name: 'co2', measurement: 'co2' }],
+    };
+    expect(chartIdentityForPanel('s:12', cellSensorsById)).toBe('u:co2');
+    expect(dedupeEquivalentPanels(['u:co2', 's:12'], cellSensorsById)).toEqual(['u:co2']);
+  });
+
+  it('treats a catalog row for another cell as the same chart', () => {
+    expect(
+      chartIdentityForCatalogEntry({
+        panelId: 's:2030',
+        kind: 'sensor',
+        sensorName: 'watermark',
+        measurement: 'soil_tension',
+      }),
+    ).toBe('sensor:watermark:soil_tension');
   });
 });

--- a/frontend/src/pages/dashboard/components/AddChartModal.jsx
+++ b/frontend/src/pages/dashboard/components/AddChartModal.jsx
@@ -19,8 +19,16 @@ import PropTypes from 'prop-types';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { getSensorCatalog } from '../../../services/catalog';
 import { catalogEntriesFromApi, FULL_CATALOG } from '../catalog/dashboardCatalog';
+import { chartIdentityForCatalogEntry, chartIdentityForPanel } from '../catalog/cellSensorLayout';
 
-function AddChartModal({ open, onClose, selectedCells, panelOrder, onAddPanel }) {
+function AddChartModal({
+  open,
+  onClose,
+  selectedCells,
+  panelOrder,
+  cellSensorsById = {},
+  onAddPanel,
+}) {
   const [pickCellId, setPickCellId] = useState(null);
   const [catalogEntries, setCatalogEntries] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -62,10 +70,15 @@ function AddChartModal({ open, onClose, selectedCells, panelOrder, onAddPanel })
     }
   }, [open, activeCellId, loadCatalog]);
 
-  const addableEntries = useMemo(
-    () => catalogEntries.filter((entry) => !panelOrder.includes(entry.panelId)),
-    [catalogEntries, panelOrder],
-  );
+  const addableEntries = useMemo(() => {
+    const occupied = new Set(
+      panelOrder.map((panelId) => chartIdentityForPanel(panelId, cellSensorsById)),
+    );
+    return catalogEntries.filter((entry) => {
+      if (panelOrder.includes(entry.panelId)) return false;
+      return !occupied.has(chartIdentityForCatalogEntry(entry));
+    });
+  }, [catalogEntries, panelOrder, cellSensorsById]);
 
   const handleSelect = (panelId) => {
     onAddPanel(panelId);
@@ -171,6 +184,7 @@ AddChartModal.propTypes = {
     }),
   ).isRequired,
   panelOrder: PropTypes.arrayOf(PropTypes.string).isRequired,
+  cellSensorsById: PropTypes.object,
   onAddPanel: PropTypes.func.isRequired,
 };
 

--- a/frontend/src/pages/dashboard/components/AddChartModal.test.jsx
+++ b/frontend/src/pages/dashboard/components/AddChartModal.test.jsx
@@ -76,4 +76,37 @@ describe('AddChartModal', () => {
 
     expect(await screen.findByText('Cell')).toBeInTheDocument();
   });
+
+  it('hides a same-type sensor chart that is already on the dashboard from another cell', async () => {
+    getSensorCatalog.mockResolvedValue([
+      {
+        panel_id: 's:2030',
+        kind: 'sensor',
+        sensor_id: 2030,
+        sensor_name: 'watermark',
+        measurement: 'soil_tension',
+        label: 'Soil Tension',
+      },
+    ]);
+
+    render(
+      <AddChartModal
+        open
+        onClose={vi.fn()}
+        selectedCells={[
+          { id: 407, name: 'Cell A' },
+          { id: 408, name: 'Cell B' },
+        ]}
+        panelOrder={['s:2029']}
+        cellSensorsById={{
+          407: [{ id: 2029, name: 'watermark', measurement: 'soil_tension' }],
+          408: [{ id: 2030, name: 'watermark', measurement: 'soil_tension' }],
+        }}
+        onAddPanel={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText('All available charts are already on the dashboard.')).toBeInTheDocument();
+    expect(screen.queryByText('Soil Tension')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes #804: adding Soil Tension (or any `s:{sensorId}` type) once per cell no longer creates duplicate panels.
- Chart identity is builtin/unified panel id, or `sensor:name:measurement` for DB sensors. Add Chart hides types already on the board; URL layouts like `s:2029,s:2030,s:2028` collapse to one panel after sensors load.
- Existing overlay behavior is unchanged: one panel still plots every selected cell as a series.

## Test plan
- [ ] Select 3 cells that share Soil Tension (or another generic sensor). Add Chart once — one panel, three series.
- [ ] Open Add Chart again for a second cell of the same type — that type is hidden / already on dashboard.
- [ ] Load a URL with duplicate `s:` ids of the same measurement — extras drop after load.
- [ ] Power / TEROS / `u:co2` add-once behavior still works.
- [ ] Frontend: `npx vitest run src/pages/dashboard/catalog/cellSensorLayout.test.js src/pages/dashboard/components/AddChartModal.test.jsx`