### PR TITLE
version bump 2.3.12

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,6 +20,6 @@ redis
 PyJWT
 Requests
 google-auth
-ents==2.3.11
+ents==2.3.12
 gevent
 eventlet


### PR DESCRIPTION
New update to the ENTS python package to 2.3.12 with new sensors:
https://github.com/jlab-sensing/ENTS-node-firmware/releases/tag/2.3.12
https://pypi.org/project/ents/